### PR TITLE
Update to use OIDC session tokens on AWS role assumption

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,8 +5,12 @@ env:
 steps:
   - name: ":docker: Build {{matrix}} base image"
     plugins:
-      - aws-assume-role-with-web-identity#v1.0.0:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role_arn: "arn:aws:iam::${BUILD_AWS_ACCOUNT_ID}:role/${BUILD_AWS_ROLE_NAME}"
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - ecr#v2.9.0:
           login: true
           account_ids: "public.ecr.aws"


### PR DESCRIPTION
Roll out using session tags for OIDC assumable IAM role trust policy.

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dist/pull/130 to be shipped first