### PR TITLE
feat: add openssl to alpine variants of base img

### DIFF
--- a/alpine-k8s/Dockerfile
+++ b/alpine-k8s/Dockerfile
@@ -38,6 +38,7 @@ RUN apk update && apk add --no-cache \
     jq \
     libc6-compat \
     openssh-client \
+    openssl \
     perl \
     py-pip \
     rsync \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
     jq \
     libc6-compat \
     openssh-client \
+    openssl \
     perl \
     py-pip \
     rsync \


### PR DESCRIPTION
## Description

Adds `openssl` to the Alpine variants of the base image to allow for parity with the Ubuntu options, which ship with `openssl` included.
