### PR TITLE
[A-1403] Build base images for Hosted Agents

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,31 +1,40 @@
 env:
-  DRY_RUN: false # set to true to disable publishing releases
   AGENT_BUILDERS_QUEUE: "${AGENT_BUILDERS_QUEUE:-elastic-builders}"
 
+common: &build-base-image
+  plugins:
+    - aws-assume-role-with-web-identity#v1.4.0:
+        role_arn: "arn:aws:iam::${BUILD_AWS_ACCOUNT_ID}:role/${BUILD_AWS_ROLE_NAME}"
+        session-tags:
+          - organization_slug
+          - organization_id
+          - pipeline_slug
+    - ecr#v2.9.0:
+        login: true
+        account_ids: "public.ecr.aws"
+  agents:
+    queue: $AGENT_BUILDERS_QUEUE
+  command: ".buildkite/steps/build-docker-base-image.sh {{matrix}}"
+  matrix:
+    setup:
+      - "alpine"
+      - "alpine-k8s"
+      - "ubuntu-focal"
+      - "ubuntu-jammy"
+      - "ubuntu-jammy-hosted"
+      - "ubuntu-noble"
+      - "ubuntu-noble-hosted"
+      - "ubuntu-resolute"
+
 steps:
-  - name: ":docker: Build {{matrix}} base image"
-    plugins:
-      - aws-assume-role-with-web-identity#v1.4.0:
-          role_arn: "arn:aws:iam::${BUILD_AWS_ACCOUNT_ID}:role/${BUILD_AWS_ROLE_NAME}"
-          session-tags:
-            - organization_slug
-            - organization_id
-            - pipeline_slug
-      - ecr#v2.9.0:
-          login: true
-          account_ids: "public.ecr.aws"
-    agents:
-      queue: $AGENT_BUILDERS_QUEUE
-    command: ".buildkite/steps/build-docker-base-image.sh {{matrix}}"
+  - branches: "main"
+    name: ":docker: Build {{matrix}} base image (main)"
     secrets:
       - AGENT_BASE_IMAGES_DOCKER_HUB_TOKEN
-    matrix:
-      setup:
-        - "alpine"
-        - "alpine-k8s"
-        - "ubuntu-focal"
-        - "ubuntu-jammy"
-        - "ubuntu-jammy-hosted"
-        - "ubuntu-noble"
-        - "ubuntu-noble-hosted"
-        - "ubuntu-resolute"
+    <<: *build-base-image
+
+  - branches: "!main"
+    name: ":docker: Build {{matrix}} base image"
+    env:
+      PUSH_IMAGE: false
+    <<: *build-base-image

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,11 +17,15 @@ steps:
     agents:
       queue: $AGENT_BUILDERS_QUEUE
     command: ".buildkite/steps/build-docker-base-image.sh {{matrix}}"
+    secrets:
+      - AGENT_BASE_IMAGES_DOCKER_HUB_TOKEN
     matrix:
       setup:
         - "alpine"
         - "alpine-k8s"
         - "ubuntu-focal"
         - "ubuntu-jammy"
+        - "ubuntu-jammy-hosted"
         - "ubuntu-noble"
+        - "ubuntu-noble-hosted"
         - "ubuntu-resolute"

--- a/.buildkite/steps/build-docker-base-image.sh
+++ b/.buildkite/steps/build-docker-base-image.sh
@@ -6,7 +6,7 @@ variant="${1:-}"
 image_tag="${2:-}"
 push="${PUSH_IMAGE:-true}"
 
-if [[ ! "${variant}" =~ ^(alpine|alpine-k8s|ubuntu-(focal|jammy|noble|resolute))$ ]]; then
+if [[ ! "${variant}" =~ ^(alpine|alpine-k8s|ubuntu-(focal|jammy|jammy-hosted|noble|noble-hosted|resolute))$ ]]; then
     echo "Unknown image variant ${variant}"
     exit 1
 fi
@@ -17,6 +17,9 @@ if [[ -n "${image_tag}" ]]; then
 else
     registry="public.ecr.aws/buildkite/agent-base"
     image_tag="${registry}:${variant}-build-${BUILDKITE_BUILD_NUMBER}"
+
+    dockerhub_registry="docker.io/buildkite/agent-base"
+    dockerhub_image_tag="${dockerhub_registry}:${variant}-build-${BUILDKITE_BUILD_NUMBER}"
 fi
 
 packaging_dir="${variant}"
@@ -56,6 +59,19 @@ docker buildx build \
     --builder "${builder_name}" \
     --tag "${image_tag}" \
     --tag "${registry}:${variant}" \
+    --platform linux/amd64,linux/arm64 \
+    --push \
+    "${packaging_dir}"
+
+echo --- :ecr: Pushing to Docker Hub
+
+echo "${AGENT_BASE_IMAGES_DOCKER_HUB_TOKEN}" | docker login --username=buildkite --password-stdin
+
+docker buildx build \
+    --progress plain \
+    --builder "${builder_name}" \
+    --tag "${dockerhub_image_tag}" \
+    --tag "${dockerhub_registry}:${variant}" \
     --platform linux/amd64,linux/arm64 \
     --push \
     "${packaging_dir}"

--- a/ubuntu-jammy-hosted/Dockerfile
+++ b/ubuntu-jammy-hosted/Dockerfile
@@ -1,0 +1,112 @@
+# syntax=docker/dockerfile:1.4
+
+FROM public.ecr.aws/ubuntu/ubuntu:22.04 AS base
+
+ARG BAZELISK_VERSION=v1.29.0
+ARG BK_CLI_VERSION=3.40.0
+
+ENV LC_CTYPE="C.UTF-8"
+
+# https://mise.jdx.dev/mise-cookbook/docker.html
+ENV MISE_DATA_DIR="/mise"
+ENV MISE_CONFIG_DIR="/mise"
+ENV MISE_CACHE_DIR="/mise/cache"
+ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
+ENV PATH="/mise/shims:$PATH"
+
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-${TARGETARCH},sharing=locked \
+--mount=type=cache,target=/var/lib/apt,id=apt-lib-${TARGETARCH},sharing=locked \
+--mount=type=cache,target=/var/cache/debconf,id=debconf-${TARGETARCH},sharing=locked \
+<<BASH
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+export ARCH=x86_64
+if [ "$(dpkg --print-architecture)" = "arm64" ]; then export ARCH=aarch64 ; fi
+
+export DEBIAN_ARCH=$(dpkg --print-architecture)
+
+# Install main packages
+apt-get update
+apt-get install -y --no-install-recommends \
+  apt-transport-https \
+  bash \
+  ca-certificates \
+  curl \
+  git \
+  git-lfs \
+  gnupg-agent \
+  jq \
+  openssh-client \
+  perl \
+  python3 \
+  python3-pip \
+  python3-dev \
+  python3-crcmod \
+  lsb-release \
+  rsync \
+  software-properties-common \
+  tini \
+  sudo \
+  bash \
+  gnupg \
+  zip \
+  unzip \
+  build-essential
+
+git --version
+git-lfs --version
+
+# install bazelisk
+curl -fLo /tmp/bazelisk.deb https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-${DEBIAN_ARCH}.deb
+dpkg -i /tmp/bazelisk.deb
+rm -f /tmp/bazelisk.deb
+
+# install buildkite-cli
+curl -fLo /tmp/bk.deb https://github.com/buildkite/cli/releases/download/v${BK_CLI_VERSION}/bk_${BK_CLI_VERSION}_linux_${DEBIAN_ARCH}.deb
+dpkg -i /tmp/bk.deb
+rm -f /tmp/bk.deb
+
+# install mise
+curl -fsL https://mise.run | bash
+
+# install aws-cli
+curl https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /opt
+/opt/aws/install --update -i /usr/local/aws-cli -b /usr/local/bin
+rm -rf /tmp/awscliv2.zip /opt/aws
+aws --version
+
+# install GCP CLI
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+apt-get update && apt-get install -y google-cloud-cli
+gcloud --version
+
+# install nodejs
+git clone https://github.com/tj/n /usr/src/n
+pushd /usr/src/n
+make install
+popd
+n lts
+rm -rf /usr/src/n /tmp/*
+node --version
+
+ln -s /usr/bin/tini /usr/sbin/tini
+
+apt clean all
+
+# Clean up apt cache
+rm -rf /var/lib/apt/lists/*
+BASH
+
+FROM base
+
+WORKDIR /root
+USER root
+

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -1,0 +1,115 @@
+# syntax=docker/dockerfile:1.4
+
+FROM public.ecr.aws/ubuntu/ubuntu:24.04 AS base
+
+ARG BAZELISK_VERSION=v1.29.0
+ARG BK_CLI_VERSION=3.40.0
+
+ENV LC_CTYPE="C.UTF-8"
+
+# https://mise.jdx.dev/mise-cookbook/docker.html
+ENV MISE_DATA_DIR="/mise"
+ENV MISE_CONFIG_DIR="/mise"
+ENV MISE_CACHE_DIR="/mise/cache"
+ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
+ENV PATH="/mise/shims:$PATH"
+
+ARG TARGETARCH
+
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-${TARGETARCH},sharing=locked \
+--mount=type=cache,target=/var/lib/apt,id=apt-lib-${TARGETARCH},sharing=locked \
+--mount=type=cache,target=/var/cache/debconf,id=debconf-${TARGETARCH},sharing=locked \
+<<BASH
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+export ARCH=x86_64
+if [ "$(dpkg --print-architecture)" = "arm64" ]; then export ARCH=aarch64 ; fi
+
+export DEBIAN_ARCH=$(dpkg --print-architecture)
+
+# Install main packages
+apt-get update
+apt-get install -y --no-install-recommends \
+  apt-transport-https \
+  bash \
+  ca-certificates \
+  curl \
+  git \
+  git-lfs \
+  gnupg-agent \
+  jq \
+  openssh-client \
+  perl \
+  python3 \
+  python3-pip \
+  python3-dev \
+  python3-crcmod \
+  lsb-release \
+  rsync \
+  software-properties-common \
+  tini \
+  sudo \
+  bash \
+  gnupg \
+  zip \
+  unzip \
+  build-essential
+
+git --version
+git-lfs --version
+
+# install bazelisk
+curl -fLo /tmp/bazelisk.deb https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-${DEBIAN_ARCH}.deb
+dpkg -i /tmp/bazelisk.deb
+rm -f /tmp/bazelisk.deb
+
+# install buildkite-cli
+curl -fLo /tmp/bk.deb https://github.com/buildkite/cli/releases/download/v${BK_CLI_VERSION}/bk_${BK_CLI_VERSION}_linux_${DEBIAN_ARCH}.deb
+dpkg -i /tmp/bk.deb
+rm -f /tmp/bk.deb
+
+# install mise
+curl -fsL https://mise.run | bash
+
+# install aws-cli
+curl https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /opt
+/opt/aws/install --update -i /usr/local/aws-cli -b /usr/local/bin
+rm -rf /tmp/awscliv2.zip /opt/aws
+aws --version
+
+# install GCP CLI
+#
+# with workaround for arm64 https://issuetracker.google.com/issues/383568269
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+apt-get update
+apt-get install -y google-cloud-cli=502.0.0-0
+gcloud --version
+
+# install nodejs
+git clone https://github.com/tj/n /usr/src/n
+pushd /usr/src/n
+make install
+popd
+n lts
+rm -rf /usr/src/n /tmp/*
+node --version
+
+ln -s /usr/bin/tini /usr/sbin/tini
+
+apt clean all
+
+# Clean up apt cache
+rm -rf /var/lib/apt/lists/*
+BASH
+
+
+FROM base
+
+WORKDIR /root
+USER root


### PR DESCRIPTION
Add two new agent-base variants for use with Buildkite Hosted Agents: 

- ubuntu-jammy-hosted
- ubuntu-noble-hosted

Also, publish the full set of agent-base variants to Docker Hub. 
