### PR TITLE
[A-1403] Build arches in parallel

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 env:
   AGENT_BUILDERS_QUEUE: "${AGENT_BUILDERS_QUEUE:-elastic-builders}"
+  PUSH_IMAGE: "false"
 
 anchor_1: &generate-variant-group
   agents:
@@ -20,9 +21,9 @@ steps:
   - branches: "main"
     <<: *generate-variant-group
     label: ":pipeline: Upload {{matrix}} group (main)"
+    env:
+      PUSH_IMAGE: "true"
 
   - branches: "!main"
     <<: *generate-variant-group
     label: ":pipeline: Upload {{variant}} group (branch)"
-    env:
-      PUSH_IMAGE: "false"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,20 +1,10 @@
 env:
   AGENT_BUILDERS_QUEUE: "${AGENT_BUILDERS_QUEUE:-elastic-builders}"
 
-common: &build-base-image
-  plugins:
-    - aws-assume-role-with-web-identity#v1.4.0:
-        role_arn: "arn:aws:iam::${BUILD_AWS_ACCOUNT_ID}:role/${BUILD_AWS_ROLE_NAME}"
-        session-tags:
-          - organization_slug
-          - organization_id
-          - pipeline_slug
-    - ecr#v2.9.0:
-        login: true
-        account_ids: "public.ecr.aws"
+anchor_1: &generate-variant-group
   agents:
     queue: $AGENT_BUILDERS_QUEUE
-  command: ".buildkite/steps/build-docker-base-image.sh {{matrix}}"
+  command: ".buildkite/steps/generate-variant-group-yml.sh '{{matrix}}' | buildkite-agent pipeline upload"
   matrix:
     setup:
       - "alpine"
@@ -28,13 +18,11 @@ common: &build-base-image
 
 steps:
   - branches: "main"
-    name: ":docker: Build {{matrix}} base image (main)"
-    secrets:
-      - AGENT_BASE_IMAGES_DOCKER_HUB_TOKEN
-    <<: *build-base-image
+    <<: *generate-variant-group
+    label: ":pipeline: Upload {{matrix}} group (main)"
 
   - branches: "!main"
-    name: ":docker: Build {{matrix}} base image"
+    <<: *generate-variant-group
+    label: ":pipeline: Upload {{variant}} group (branch)"
     env:
-      PUSH_IMAGE: false
-    <<: *build-base-image
+      PUSH_IMAGE: "false"

--- a/.buildkite/steps/build-docker-base-image.sh
+++ b/.buildkite/steps/build-docker-base-image.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+#
+# Usage:
+# build-docker-base-image.sh <variant> <arch>
+# e.g. build-docker-base-image.sh alpine-k8s arm64
+#
+# Builds the base image for a given variant and arch.
+# When PUSH_IMAGE=true, it pushes the image to Docker Hub and ECR
+# and records the image digest in Buildkite meta-data.
 
 set -Eeufo pipefail
 

--- a/.buildkite/steps/build-docker-base-image.sh
+++ b/.buildkite/steps/build-docker-base-image.sh
@@ -37,9 +37,7 @@ trap "docker buildx rm ${builder_name} || true" EXIT
 echo "--- Copy files into build context"
 cp common/docker-compose "${packaging_dir}"
 
-push="${PUSH_IMAGE:-true}"
-
-if [[ "${push}" != "true" ]]; then
+if [[ "${PUSH_IMAGE:-}" != "true" ]]; then
     echo "--- :docker: Building ${variant}-${arch} (no push)"
     docker buildx build \
         --progress plain \

--- a/.buildkite/steps/build-docker-base-image.sh
+++ b/.buildkite/steps/build-docker-base-image.sh
@@ -3,75 +3,68 @@
 set -Eeufo pipefail
 
 variant="${1:-}"
-image_tag="${2:-}"
-push="${PUSH_IMAGE:-true}"
+arch="${2:-}"
 
+# Validate variant
 if [[ ! "${variant}" =~ ^(alpine|alpine-k8s|ubuntu-(focal|jammy|jammy-hosted|noble|noble-hosted|resolute))$ ]]; then
-    echo "Unknown image variant ${variant}"
+    echo "Unknown image variant '${variant}'"
     exit 1
 fi
 
-# Disable pushing if run manually
-if [[ -n "${image_tag}" ]]; then
-    push="false"
-else
-    registry="public.ecr.aws/buildkite/agent-base"
-    image_tag="${registry}:${variant}-build-${BUILDKITE_BUILD_NUMBER}"
-
-    dockerhub_registry="docker.io/buildkite/agent-base"
-    dockerhub_image_tag="${dockerhub_registry}:${variant}-build-${BUILDKITE_BUILD_NUMBER}"
+# Validate arch
+if [[ ! "${arch}" =~ ^(amd64|arm64)$ ]]; then
+    echo "Invalid arch '${arch}': must be amd64 or arm64"
+    exit 1
 fi
 
+platform="linux/${arch}"
 packaging_dir="${variant}"
 
-echo "--- Building :docker: base image for ${variant}"
+echo "--- Build :docker: base image for ${variant} on ${platform}"
 
 builder_name="$(docker buildx create --use)"
 # shellcheck disable=SC2064 # we want the current $builder_name to be trapped, not the runtime one
 trap "docker buildx rm ${builder_name} || true" EXIT
 
-echo --- Copying files into build context
+echo "--- Copy files into build context"
 cp common/docker-compose "${packaging_dir}"
 
-echo "--- Building :docker: ${image_tag} for all architectures"
-docker buildx build --progress plain --builder "${builder_name}" --platform linux/amd64,linux/arm64 "${packaging_dir}"
-
-# Tag images for just the native architecture. There is a limitation in docker that prevents this
-# from being done in one command. Luckliy the second build will be quick because of docker layer caching
-# As this is just a native build, we don't need the lock.
-docker buildx build --progress plain --builder "${builder_name}" --tag "${image_tag}" --load "${packaging_dir}"
+push="${PUSH_IMAGE:-true}"
 
 if [[ "${push}" != "true" ]]; then
+    echo "--- :docker: Building ${variant}-${arch} (no push)"
+    docker buildx build \
+        --progress plain \
+        --builder "${builder_name}" \
+        --platform "${platform}" \
+        "${packaging_dir}"
     exit 0
 fi
 
-echo --- :ecr: Pushing to ECR
+metadata_file="${BUILDKITE_BUILD_CHECKOUT_PATH:-.}/metadata-${variant}-${arch}.json"
 
-# Do another build with all architectures. The layers should be cached from the previous build
-# with all architectures.
-# Pushing to the docker registry in this way greatly simplifies creating the manifest list on
-# the docker registry so that either architecture can be pulled with the same tag.
-#
-# Also push the raw variant as a tag - that way Dependabot can be pointed at a
-# mutable tag for updates.
-docker buildx build \
-    --progress plain \
-    --builder "${builder_name}" \
-    --tag "${image_tag}" \
-    --tag "${registry}:${variant}" \
-    --platform linux/amd64,linux/arm64 \
-    --push \
-    "${packaging_dir}"
+echo "--- :docker: Build and push ${variant} (${platform}) by digest"
 
-echo --- :ecr: Pushing to Docker Hub
+dockerhub_registry="docker.io/buildkite/agent-base"
+ecr_registry="public.ecr.aws/buildkite/agent-base"
 
+# Login to Docker Hub. ECR login handled by `ecr` pipeline plugin.
 echo "${AGENT_BASE_IMAGES_DOCKER_HUB_TOKEN}" | docker login --username=buildkite --password-stdin
 
+# Push both registries in a single build using comma-separated name= entries.
 docker buildx build \
     --progress plain \
     --builder "${builder_name}" \
-    --tag "${dockerhub_image_tag}" \
-    --tag "${dockerhub_registry}:${variant}" \
-    --platform linux/amd64,linux/arm64 \
-    --push \
+    --platform "${platform}" \
+    --metadata-file "${metadata_file}" \
+    --output "type=image,\"name=${dockerhub_registry},${ecr_registry}\",push-by-digest=true,name-canonical=true,push=true" \
     "${packaging_dir}"
+
+digest="$(jq -r '."containerimage.digest"' "${metadata_file}")"
+
+echo "--- :docker: Pushed digests"
+echo "  Digest:     ${digest}"
+echo "  Docker Hub: ${dockerhub_registry}@${digest}"
+echo "  ECR:        ${ecr_registry}@${digest}"
+
+buildkite-agent meta-data set "image-digest-${variant}-${arch}" "${digest}"

--- a/.buildkite/steps/build-docker-base-image.sh
+++ b/.buildkite/steps/build-docker-base-image.sh
@@ -10,14 +10,14 @@
 
 set -Eeufo pipefail
 
-variant="${1:-}"
+# shellcheck source=.buildkite/steps/lib/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+
+variant="${1:?variant required}"
 arch="${2:-}"
 
 # Validate variant
-if [[ ! "${variant}" =~ ^(alpine|alpine-k8s|ubuntu-(focal|jammy|jammy-hosted|noble|noble-hosted|resolute))$ ]]; then
-    echo "Unknown image variant '${variant}'"
-    exit 1
-fi
+validate_variant "${variant}"
 
 # Validate arch
 if [[ ! "${arch}" =~ ^(amd64|arm64)$ ]]; then

--- a/.buildkite/steps/generate-variant-group-yml.sh
+++ b/.buildkite/steps/generate-variant-group-yml.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# Usage:
+# generate-variant-group-yml.sh <variant> | buildkite-agent pipeline upload
+# e.g. generate-variant-group-yml.sh alpine-k8s | buildkite-agent pipeline upload
+#
+# Generates the dynamic pipeline YAML Group Step for a variant and outputs to STDOUT.
+# It runs `build-docker-base-image.sh` per <arch>.
+# When PUSH_IMAGE=true, the images are pushed and `publish-multiarch-manifest.sh`
+# publishes a multiarch variant of the image to Docker Hub and ECR.
+
 set -Eeufo pipefail
 
 variant="${1:?variant required}"

--- a/.buildkite/steps/generate-variant-group-yml.sh
+++ b/.buildkite/steps/generate-variant-group-yml.sh
@@ -11,13 +11,13 @@
 
 set -Eeufo pipefail
 
+# shellcheck source=.buildkite/steps/lib/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+
 variant="${1:?variant required}"
 
-# Validate variant — same regex as build-docker-base-image.sh
-if [[ ! "${variant}" =~ ^(alpine|alpine-k8s|ubuntu-(focal|jammy|jammy-hosted|noble|noble-hosted|resolute))$ ]]; then
-    echo "Unknown image variant '${variant}'" >&2
-    exit 1
-fi
+# Validate variant
+validate_variant "${variant}"
 
 # Reusable anchor
 cat <<EOF

--- a/.buildkite/steps/generate-variant-group-yml.sh
+++ b/.buildkite/steps/generate-variant-group-yml.sh
@@ -25,7 +25,7 @@ anchor_1: &build-and-publish-variant
   agents:
     queue: "${AGENT_BUILDERS_QUEUE}"
   env:
-    PUSH_IMAGE: "${PUSH_IMAGE}"
+    PUSH_IMAGE: "${PUSH_IMAGE:-}"
   plugins:
     - aws-assume-role-with-web-identity#v1.4.0:
         role_arn: "arn:aws:iam::\${BUILD_AWS_ACCOUNT_ID}:role/\${BUILD_AWS_ROLE_NAME}"

--- a/.buildkite/steps/generate-variant-group-yml.sh
+++ b/.buildkite/steps/generate-variant-group-yml.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -Eeufo pipefail
+
+variant="${1:?variant required}"
+
+# Validate variant — same regex as build-docker-base-image.sh
+if [[ ! "${variant}" =~ ^(alpine|alpine-k8s|ubuntu-(focal|jammy|jammy-hosted|noble|noble-hosted|resolute))$ ]]; then
+    echo "Unknown image variant '${variant}'" >&2
+    exit 1
+fi
+
+# Reusable anchor
+cat <<EOF
+anchor_1: &build-and-publish-variant
+  agents:
+    queue: "${AGENT_BUILDERS_QUEUE}"
+  env:
+    PUSH_IMAGE: "${PUSH_IMAGE}"
+  plugins:
+    - aws-assume-role-with-web-identity#v1.4.0:
+        role_arn: "arn:aws:iam::\${BUILD_AWS_ACCOUNT_ID}:role/\${BUILD_AWS_ROLE_NAME}"
+        session-tags:
+          - organization_slug
+          - organization_id
+          - pipeline_slug
+    - ecr#v2.9.0:
+        login: true
+        account_ids: "public.ecr.aws"
+EOF
+
+
+# Emit secret in anchor if pushing image
+if [[ "${PUSH_IMAGE:-}" == "true" ]]; then
+cat <<EOF
+  secrets:
+    - AGENT_BASE_IMAGES_DOCKER_HUB_TOKEN
+EOF
+fi
+
+# Emit start of Step Group
+cat <<EOF
+steps:
+  - group: ":docker: ${variant}"
+    key: "build-${variant}"
+    steps:
+EOF
+
+# Emit one `build` step per arch
+for arch in amd64 arm64; do
+    cat <<EOF
+      - <<: *build-and-publish-variant
+        label: ":docker: Build ${variant} ${arch} base image"
+        agents:
+          queue: "agent-runners-linux-${arch}"
+        command: ".buildkite/steps/build-docker-base-image.sh ${variant} ${arch}"
+EOF
+done
+
+# Emit one `publish` step per variant behind a wait block if pushing image
+if [[ "${PUSH_IMAGE:-}" == "true" ]]; then
+    cat <<EOF
+      - wait
+      - <<: *build-and-publish-variant
+        label: ":docker: Publish ${variant} multiarch manifest"
+        command: ".buildkite/steps/publish-multiarch-manifest.sh ${variant}"
+EOF
+fi

--- a/.buildkite/steps/lib/common.sh
+++ b/.buildkite/steps/lib/common.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for .buildkite/steps/*.sh
+#
+# This file must produce NO output when sourced, because some
+# callers pipe their STDOUT to `buildkite-agent pipeline upload`.
+
+VARIANT_REGEX='^(alpine|alpine-k8s|ubuntu-(focal|jammy|jammy-hosted|noble|noble-hosted|resolute))$'
+
+# validate_variant <variant>
+# Returns 0 if the variant is valid, otherwise prints an error to stderr and
+# returns 1. Produces no output on success.
+validate_variant() {
+    local variant="${1:-}"
+    if [[ ! "${variant}" =~ ${VARIANT_REGEX} ]]; then
+        echo "Unknown image variant '${variant}'" >&2
+        return 1
+    fi
+}

--- a/.buildkite/steps/publish-multiarch-manifest.sh
+++ b/.buildkite/steps/publish-multiarch-manifest.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Usage:
+# publish-multiarch-manifest.sh <variant>
+# e.g. publish-multiarch-manifest.sh alpine-k8s
+#
+# Publishes a multiarch manifest list for a variant to Docker Hub and ECR by
+# combining the per-arch image digests stored in Buildkite meta-data.
+
 set -Eeufo pipefail
 
 variant="${1:?variant required}"

--- a/.buildkite/steps/publish-multiarch-manifest.sh
+++ b/.buildkite/steps/publish-multiarch-manifest.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -Eeufo pipefail
+
+variant="${1:?variant required}"
+
+# Validate variant
+if [[ ! "${variant}" =~ ^(alpine|alpine-k8s|ubuntu-(focal|jammy|jammy-hosted|noble|noble-hosted|resolute))$ ]]; then
+    echo "Unknown image variant '${variant}'" >&2
+    exit 1
+fi
+
+# Arches to publish
+arches=(amd64 arm64)
+
+if [[ -z "${BUILDKITE_BUILD_NUMBER:-}" ]]; then
+    echo "BUILDKITE_BUILD_NUMBER is not set" >&2
+    exit 1
+fi
+
+# Compute image tags
+variant_tag="${variant}"
+build_tag="${variant}-build-${BUILDKITE_BUILD_NUMBER}"
+
+echo "--- :docker: Resolve per-arch digests for ${variant}"
+echo "  Variant: ${variant}"
+echo "  Arches:  ${arches[*]}"
+echo "  Tags:    ${variant_tag}, ${build_tag}"
+
+# Resolve digests from Buildkite meta-data
+declare -A digests=()
+for arch in "${arches[@]}"; do
+    meta_key="image-digest-${variant}-${arch}"
+    digest="$(buildkite-agent meta-data get "${meta_key}")"
+    if [[ -z "${digest}" ]]; then
+        echo "Expected meta-data key '${meta_key}' is empty or missing" >&2
+        exit 1
+    fi
+    echo "  ${arch}: ${digest}"
+    digests["${arch}"]="${digest}"
+done
+
+dockerhub_registry="docker.io/buildkite/agent-base"
+ecr_registry="public.ecr.aws/buildkite/agent-base"
+
+# Login to Docker Hub. ECR login handled by `ecr` pipeline plugin.
+echo "${AGENT_BASE_IMAGES_DOCKER_HUB_TOKEN}" | docker login --username=buildkite --password-stdin
+
+# Publish multiarch manifest to each registry
+for registry in "${dockerhub_registry}" "${ecr_registry}"; do
+    echo "--- :docker: Publishing manifest list to ${registry}"
+
+    # Build source list: registry@digest for each arch
+    sources=()
+    for arch in "${arches[@]}"; do
+        sources+=("${registry}@${digests[${arch}]}")
+    done
+
+    docker buildx imagetools create \
+        -t "${registry}:${variant_tag}" \
+        -t "${registry}:${build_tag}" \
+        "${sources[@]}"
+
+    echo "--- :docker: Inspecting manifest list on ${registry}"
+    docker buildx imagetools inspect "${registry}:${variant_tag}"
+done

--- a/.buildkite/steps/publish-multiarch-manifest.sh
+++ b/.buildkite/steps/publish-multiarch-manifest.sh
@@ -9,13 +9,13 @@
 
 set -Eeufo pipefail
 
+# shellcheck source=.buildkite/steps/lib/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+
 variant="${1:?variant required}"
 
 # Validate variant
-if [[ ! "${variant}" =~ ^(alpine|alpine-k8s|ubuntu-(focal|jammy|jammy-hosted|noble|noble-hosted|resolute))$ ]]; then
-    echo "Unknown image variant '${variant}'" >&2
-    exit 1
-fi
+validate_variant "${variant}"
 
 # Arches to publish
 arches=(amd64 arm64)


### PR DESCRIPTION
Modify the pipeline to build the each (e.g. `amd64`, `arm64`) for each variant (e.g. `alpine-k8s`) in a parallel step.

## Demo

### Before
<img width="1413" height="569" alt="Screenshot 2026-06-23 at 1 50 27 pm" src="https://github.com/user-attachments/assets/5088d8e0-8be2-4d06-b9c0-8aff1dcc834f" />

### After
<img width="1413" height="1255" alt="Screenshot 2026-06-23 at 1 50 42 pm" src="https://github.com/user-attachments/assets/eb19afe1-24ed-413a-97a7-33d4066ce21d" />

## Design notes
- Main **pipeline.yml** now generates a Group Step per-variant via e.g. `.buildkite/steps/generate-variant-group-yml.sh alpine-k8s` with a matrix.

- Each variant Group Step builds `amd64` and `arm64` arch in two parallel steps on arch-native hosts. When both are completed, a final step in the group publishes a multi-platform manifest for the image variant based on image digests from the preceding per-arch build steps. This is passed along via `buildkite-agent meta-data`.

## Changes

- **generate-variant-group-yml.sh** replaces multi-arch `docker buildx build` in **build-docker-base-image.sh**. 
- **build-docker-base-image.sh** now takes `<variant> <arch>` arguments (e.g. `alpine-k8s amd64`). It builds a single variant-arch image and pushes it to both Public ECR and Docker Hub by its digest only.
- arm64 arch images are now built on the `agent-runners-linux-arm64` agent queue.
- **publish-multiarch-manifest.sh** publishes a multi-arch manifest behind the per-variant tags (e.g. `buildkite/agent-base:alpine-k8s` and `buildkite/agent-base:alpine-k8s-build-<nnn>`
