### PR TITLE
[A-1669][PB-2687] Add opt-in preloaded toolchain variants for Linux Hosted images

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,8 +13,10 @@ anchor_1: &generate-variant-group
       - "ubuntu-focal"
       - "ubuntu-jammy"
       - "ubuntu-jammy-hosted"
+      - "ubuntu-jammy-hosted-toolchains"
       - "ubuntu-noble"
       - "ubuntu-noble-hosted"
+      - "ubuntu-noble-hosted-toolchains"
       - "ubuntu-resolute"
 
 steps:

--- a/.buildkite/steps/build-docker-base-image.sh
+++ b/.buildkite/steps/build-docker-base-image.sh
@@ -27,6 +27,22 @@ fi
 
 platform="linux/${arch}"
 packaging_dir="${variant}"
+build_context="${packaging_dir}"
+build_args=()
+
+case "${variant}" in
+    ubuntu-jammy-hosted-toolchains|ubuntu-noble-hosted-toolchains)
+        packaging_dir="${variant%-toolchains}"
+        build_context="."
+        build_args=(--file "${packaging_dir}/Dockerfile" --target toolchains)
+        ;;
+    ubuntu-jammy-hosted|ubuntu-noble-hosted)
+        # These Dockerfiles share the toolchain installer from the repository
+        # root, even though their default target remains the slim Hosted image.
+        build_context="."
+        build_args=(--file "${packaging_dir}/Dockerfile")
+        ;;
+esac
 
 echo "--- Build :docker: base image for ${variant} on ${platform}"
 
@@ -34,8 +50,10 @@ builder_name="$(docker buildx create --use)"
 # shellcheck disable=SC2064 # we want the current $builder_name to be trapped, not the runtime one
 trap "docker buildx rm ${builder_name} || true" EXIT
 
-echo "--- Copy files into build context"
-cp common/docker-compose "${packaging_dir}"
+if [[ "${build_context}" != "." ]]; then
+    echo "--- Copy files into build context"
+    cp common/docker-compose "${packaging_dir}"
+fi
 
 if [[ "${PUSH_IMAGE:-}" != "true" ]]; then
     echo "--- :docker: Building ${variant}-${arch} (no push)"
@@ -43,7 +61,8 @@ if [[ "${PUSH_IMAGE:-}" != "true" ]]; then
         --progress plain \
         --builder "${builder_name}" \
         --platform "${platform}" \
-        "${packaging_dir}"
+        "${build_args[@]}" \
+        "${build_context}"
     exit 0
 fi
 
@@ -64,7 +83,8 @@ docker buildx build \
     --platform "${platform}" \
     --metadata-file "${metadata_file}" \
     --output "type=image,\"name=${dockerhub_registry},${ecr_registry}\",push-by-digest=true,name-canonical=true,push=true" \
-    "${packaging_dir}"
+    "${build_args[@]}" \
+    "${build_context}"
 
 digest="$(jq -r '."containerimage.digest"' "${metadata_file}")"
 

--- a/.buildkite/steps/build-docker-base-image.sh
+++ b/.buildkite/steps/build-docker-base-image.sh
@@ -27,20 +27,25 @@ fi
 
 platform="linux/${arch}"
 packaging_dir="${variant}"
+
+# `-toolchains` variants are virtual, so rewrite packaging_dir to their real parents
+if [[ "${variant}" == *-toolchains ]]; then
+    packaging_dir="${variant%-toolchains}" # e.g. ubuntu-jammy-hosted-toolchains → ubuntu-jammy-hosted
+fi
+
 build_context="${packaging_dir}"
 build_args=()
 
+# - Rewrite `build_context` here because these images need access to common/install-mise-toolchains.sh
+# - Rewrite `build_args` here to adapt to new `build_context` and to specify custom --target for `toolchains`
 case "${variant}" in
-    ubuntu-jammy-hosted-toolchains|ubuntu-noble-hosted-toolchains)
-        packaging_dir="${variant%-toolchains}"
-        build_context="."
-        build_args=(--file "${packaging_dir}/Dockerfile" --target toolchains)
-        ;;
     ubuntu-jammy-hosted|ubuntu-noble-hosted)
-        # These Dockerfiles share the toolchain installer from the repository
-        # root, even though their default target remains the slim Hosted image.
         build_context="."
         build_args=(--file "${packaging_dir}/Dockerfile")
+        ;;
+    ubuntu-jammy-hosted-toolchains|ubuntu-noble-hosted-toolchains)
+        build_context="."
+        build_args=(--file "${packaging_dir}/Dockerfile" --target toolchains)
         ;;
 esac
 

--- a/.buildkite/steps/lib/common.sh
+++ b/.buildkite/steps/lib/common.sh
@@ -5,7 +5,7 @@
 # This file must produce NO output when sourced, because some
 # callers pipe their STDOUT to `buildkite-agent pipeline upload`.
 
-VARIANT_REGEX='^(alpine|alpine-k8s|ubuntu-(focal|jammy|jammy-hosted|noble|noble-hosted|resolute))$'
+VARIANT_REGEX='^(alpine|alpine-k8s|ubuntu-(focal|jammy|jammy-hosted|jammy-hosted-toolchains|noble|noble-hosted|noble-hosted-toolchains|resolute))$'
 
 # validate_variant <variant>
 # Returns 0 if the variant is valid, otherwise prints an error to stderr and

--- a/README.md
+++ b/README.md
@@ -41,19 +41,26 @@ and other common system tools.
 | Tag | Description |
 | - | - |
 | [ubuntu-jammy-hosted](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-jammy-hosted) | Ubuntu 22.04 LTS base for Hosted Agents |
+| [ubuntu-jammy-hosted-toolchains](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-jammy-hosted-toolchains) | Ubuntu 22.04 LTS Hosted base with preloaded mise toolchains |
 | [ubuntu-noble-hosted](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-noble-hosted) | Ubuntu 24.04 LTS base for Hosted Agents |
+| [ubuntu-noble-hosted-toolchains](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-noble-hosted-toolchains) | Ubuntu 24.04 LTS Hosted base with preloaded mise toolchains |
 
 ### Preloaded Hosted toolchains
 
-The Linux Hosted variants preload a small common toolchain using mise:
+The opt-in `ubuntu-jammy-hosted-toolchains` and
+`ubuntu-noble-hosted-toolchains` variants preload a common toolchain using
+mise. The corresponding Hosted variants without the `-toolchains` suffix
+remain the smaller default images.
+
+The preloaded toolchain contains:
 
 - Node.js 20.20.2 and 24.18.0
 - the latest patch release from each supported Go 1.24, 1.25, and 1.26 line
 - the latest stable Ruby for which mise has a precompiled binary
 
 The Go and Ruby versions are resolved to exact versions during each image
-build. The image records those versions, its architecture, the pinned mise
-version, canonical install roots, and executable SHA-256 digests in
+build. Each toolchain image records those versions, its architecture, the
+pinned mise version, canonical install roots, and executable SHA-256 digests in
 `/opt/buildkite/mise-toolchains/manifest.json`.
 
 Toolchain bytes live only under `/opt/buildkite/mise-toolchains/installs`.
@@ -63,11 +70,12 @@ Actions tool-cache layout (`node`, `go`, and `Ruby`) without copying the SDKs.
 This compatibility layout is not a claim of full GitHub-hosted Ubuntu image
 parity.
 
-The image keeps mise itself at `/usr/local/bin/mise`; it does not install
-`/mise/bin/mise`, so `jdx/mise-action` remains free to install its requested
-mise version. Reusing the preloaded toolchains from `jdx/mise-action` still
-requires the workload runtime to preserve `MISE_DATA_DIR=/mise`. These images
-provide the seed and filesystem layout but do not configure `buildkite-gha`.
+The toolchain images keep mise itself at `/usr/local/bin/mise`; they do not
+install `/mise/bin/mise`, so `jdx/mise-action` remains free to install its
+requested mise version. Reusing the preloaded toolchains from
+`jdx/mise-action` still requires the workload runtime to preserve
+`MISE_DATA_DIR=/mise`. These images provide the seed and filesystem layout but
+do not configure `buildkite-gha`.
 
 ### Why Ubuntu codenames?
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,32 @@ and other common system tools.
 | [ubuntu-jammy-hosted](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-jammy-hosted) | Ubuntu 22.04 LTS base for Hosted Agents |
 | [ubuntu-noble-hosted](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-noble-hosted) | Ubuntu 24.04 LTS base for Hosted Agents |
 
+### Preloaded Hosted toolchains
+
+The Linux Hosted variants preload a small common toolchain using mise:
+
+- Node.js 20.20.2 and 24.18.0
+- the latest patch release from each supported Go 1.24, 1.25, and 1.26 line
+- the latest stable Ruby for which mise has a precompiled binary
+
+The Go and Ruby versions are resolved to exact versions during each image
+build. The image records those versions, its architecture, the pinned mise
+version, canonical install roots, and executable SHA-256 digests in
+`/opt/buildkite/mise-toolchains/manifest.json`.
+
+Toolchain bytes live only under `/opt/buildkite/mise-toolchains/installs`.
+Native mise discovers the same installs through links under `/mise/installs`.
+The matching `/opt/hostedtoolcache` entries provide the case-sensitive
+Actions tool-cache layout (`node`, `go`, and `Ruby`) without copying the SDKs.
+This compatibility layout is not a claim of full GitHub-hosted Ubuntu image
+parity.
+
+The image keeps mise itself at `/usr/local/bin/mise`; it does not install
+`/mise/bin/mise`, so `jdx/mise-action` remains free to install its requested
+mise version. Reusing the preloaded toolchains from `jdx/mise-action` still
+requires the workload runtime to preserve `MISE_DATA_DIR=/mise`. These images
+provide the seed and filesystem layout but do not configure `buildkite-gha`.
+
 ### Why Ubuntu codenames?
 
 This makes Dependabot slightly easier to work with. When tagged with version

--- a/README.md
+++ b/README.md
@@ -54,21 +54,24 @@ remain the smaller default images.
 
 The preloaded toolchain contains:
 
-- Node.js 20.20.2 and 24.18.0
+- Node.js 22.23.2 and 24.18.0
 - the latest patch release from each supported Go 1.24, 1.25, and 1.26 line
 - the latest stable Ruby for which mise has a precompiled binary
 
-The Go and Ruby versions are resolved to exact versions during each image
-build. Each toolchain image records those versions, its architecture, the
-pinned mise version, canonical install roots, and executable SHA-256 digests in
+The Node versions are exact pins derived from the same release source used by
+the GitHub runner-image toolsets. The Go and Ruby versions are resolved to
+exact versions during each image build. Each toolchain image records those
+versions, its architecture, the pinned mise version, canonical install roots,
+and executable SHA-256 digests in
 `/opt/buildkite/mise-toolchains/manifest.json`.
 
 Toolchain bytes live only under `/opt/buildkite/mise-toolchains/installs`.
 Native mise discovers the same installs through links under `/mise/installs`.
-The matching `/opt/hostedtoolcache` entries provide the case-sensitive
-Actions tool-cache layout (`node`, `go`, and `Ruby`) without copying the SDKs.
-This compatibility layout is not a claim of full GitHub-hosted Ubuntu image
-parity.
+Node 24 at that canonical root is the default `node` on `PATH`. The matching
+`/opt/hostedtoolcache` entries provide the case-sensitive setup-action tool
+cache layout (`node`, `go`, and `Ruby`) without copying the SDKs. This cache is
+not the runner-bundled Node runtime used to execute JavaScript actions. The
+compatibility layout is not a claim of full GitHub-hosted Ubuntu image parity.
 
 The toolchain images keep mise itself at `/usr/local/bin/mise`; they do not
 install `/mise/bin/mise`, so `jdx/mise-action` remains free to install its

--- a/README.md
+++ b/README.md
@@ -41,44 +41,36 @@ and other common system tools.
 | Tag | Description |
 | - | - |
 | [ubuntu-jammy-hosted](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-jammy-hosted) | Ubuntu 22.04 LTS base for Hosted Agents |
-| [ubuntu-jammy-hosted-toolchains](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-jammy-hosted-toolchains) | Ubuntu 22.04 LTS Hosted base with preloaded mise toolchains |
 | [ubuntu-noble-hosted](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-noble-hosted) | Ubuntu 24.04 LTS base for Hosted Agents |
-| [ubuntu-noble-hosted-toolchains](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-noble-hosted-toolchains) | Ubuntu 24.04 LTS Hosted base with preloaded mise toolchains |
 
-### Preloaded Hosted toolchains
+## Hosted Toolchains Variants
 
-The opt-in `ubuntu-jammy-hosted-toolchains` and
-`ubuntu-noble-hosted-toolchains` variants preload a common toolchain using
-mise. The corresponding Hosted variants without the `-toolchains` suffix
-remain the smaller default images.
+Hosted toolchain variants preloaded with mise:
 
-The preloaded toolchain contains:
-
-- Node.js 22.23.2 and 24.18.0
+- two Node.js LTS lines (22 and 24), pinned via the `NODE_22_VERSION` and
+  `NODE_24_VERSION` build args in the `-hosted` Dockerfiles
 - the latest patch release from each supported Go 1.24, 1.25, and 1.26 line
 - the latest stable Ruby for which mise has a precompiled binary
 
-The Node versions are exact pins derived from the same release source used by
-the GitHub runner-image toolsets. The Go and Ruby versions are resolved to
-exact versions during each image build. Each toolchain image records those
-versions, its architecture, the pinned mise version, canonical install roots,
-and executable SHA-256 digests in
+The exact Node versions are the source of truth in the `-hosted` Dockerfiles and
+track the GitHub runner-image toolsets; Go and Ruby resolve to exact versions at
+build time. The image records these versions, its architecture, mise version,
+install roots, and executable SHA-256 digests in
 `/opt/buildkite/mise-toolchains/manifest.json`.
 
-Toolchain bytes live only under `/opt/buildkite/mise-toolchains/installs`.
-Native mise discovers the same installs through links under `/mise/installs`.
-Node 24 at that canonical root is the default `node` on `PATH`. The matching
-`/opt/hostedtoolcache` entries provide the case-sensitive setup-action tool
-cache layout (`node`, `go`, and `Ruby`) without copying the SDKs. This cache is
-not the runner-bundled Node runtime used to execute JavaScript actions. The
-compatibility layout is not a claim of full GitHub-hosted Ubuntu image parity.
+Toolchains are stored once under `/opt/buildkite/mise-toolchains/installs` and
+linked into mise's `/mise/installs` and `/opt/hostedtoolcache` (`node`, `go`, and
+`Ruby`) for setup actions. Node 24 is the default on `PATH`; the cache is not the
+runner's JavaScript runtime or full GitHub-hosted Ubuntu parity.
 
-The toolchain images keep mise itself at `/usr/local/bin/mise`; they do not
-install `/mise/bin/mise`, so `jdx/mise-action` remains free to install its
-requested mise version. Reusing the preloaded toolchains from
-`jdx/mise-action` still requires the workload runtime to preserve
-`MISE_DATA_DIR=/mise`. These images provide the seed and filesystem layout but
-do not configure `buildkite-gha`.
+Mise is installed at `/usr/local/bin/mise`, not `/mise/bin/mise`, so `jdx/mise-action`
+can install its requested version. Reuse requires `MISE_DATA_DIR=/mise`; the
+images do not configure `buildkite-gha`.
+
+| Tag | Description |
+| - | - |
+| [ubuntu-jammy-hosted-toolchains](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-jammy-hosted-toolchains) | Ubuntu 22.04 LTS Hosted base with preloaded mise toolchains |
+| [ubuntu-noble-hosted-toolchains](https://hub.docker.com/layers/buildkite/agent-base/ubuntu-noble-hosted-toolchains) | Ubuntu 24.04 LTS Hosted base with preloaded mise toolchains |
 
 ### Why Ubuntu codenames?
 

--- a/common/install-mise-default-node.sh
+++ b/common/install-mise-default-node.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -Eeufo pipefail
+
+: "${MISE_VERSION:?}"
+: "${MISE_SHA256_AMD64:?}"
+: "${MISE_SHA256_ARM64:?}"
+: "${NODE_24_VERSION:?}"
+
+mise_arch=x64
+mise_sha256="${MISE_SHA256_AMD64}"
+if [[ "$(dpkg --print-architecture)" == "arm64" ]]; then
+  mise_arch=arm64
+  mise_sha256="${MISE_SHA256_ARM64}"
+fi
+
+curl -fLo /usr/local/bin/mise "https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-${mise_arch}"
+echo "${mise_sha256}  /usr/local/bin/mise" | sha256sum --check
+chmod 0755 /usr/local/bin/mise
+test "$(mise --version | awk '{print $1}')" = "${MISE_VERSION#v}"
+
+# Install the default Node at the root reused by the toolchains target.
+node_24_root="/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}"
+MISE_DATA_DIR=/opt/buildkite/mise-toolchains \
+  MISE_CONFIG_DIR=/tmp/mise-config \
+  MISE_CACHE_DIR=/tmp/mise-cache \
+  mise install "node@${NODE_24_VERSION}"
+test -d "${node_24_root}"
+test ! -L "${node_24_root}"
+test "$(readlink -f "$(command -v node)")" = "${node_24_root}/bin/node"
+test "$(node --version)" = "v${NODE_24_VERSION}"
+rm -rf /tmp/mise-cache /tmp/mise-config /opt/buildkite/mise-toolchains/downloads

--- a/common/install-mise-toolchains.sh
+++ b/common/install-mise-toolchains.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eufo pipefail
+set -Eeufo pipefail
 
 : "${MISE_VERSION:?}"
 : "${NODE_22_VERSION:?}"

--- a/common/install-mise-toolchains.sh
+++ b/common/install-mise-toolchains.sh
@@ -3,7 +3,7 @@
 set -eufo pipefail
 
 : "${MISE_VERSION:?}"
-: "${NODE_20_VERSION:?}"
+: "${NODE_22_VERSION:?}"
 : "${NODE_24_VERSION:?}"
 
 export DEBIAN_ARCH="$(dpkg --print-architecture)"
@@ -110,7 +110,7 @@ url = "${RUBY_ARM64_URL}"
 checksum = "${RUBY_ARM64_SHA256}"
 TOML
 
-canonical_mise install "node@${NODE_20_VERSION}"
+canonical_mise install "node@${NODE_22_VERSION}"
 canonical_mise install "node@${NODE_24_VERSION}"
 canonical_mise install "go@${GO_124_VERSION}"
 canonical_mise install "go@${GO_125_VERSION}"
@@ -158,7 +158,7 @@ register_tool() {
   test "$(readlink -f "${toolcache_root}")" = "${canonical_root}"
 }
 
-register_tool node node "${NODE_20_VERSION}" bin/node
+register_tool node node "${NODE_22_VERSION}" bin/node
 register_tool node node "${NODE_24_VERSION}" bin/node
 register_tool go go "${GO_124_VERSION}" bin/go
 register_tool go go "${GO_125_VERSION}" bin/go
@@ -167,13 +167,17 @@ register_tool ruby Ruby "${RUBY_VERSION}" bin/ruby
 
 test ! -e /mise/bin/mise
 
-for version in "${NODE_20_VERSION}" "${NODE_24_VERSION}"; do
+for version in "${NODE_22_VERSION}" "${NODE_24_VERSION}"; do
   canonical_root="${TOOLCHAIN_DATA_DIR}/installs/node/${version}"
   test "$(readlink -f "$(mise where "node@${version}")")" = "${canonical_root}"
   test "$(mise exec "node@${version}" -- node --version)" = "v${version}"
   EXPECTED_NODE_VERSION="${version}" mise exec "node@${version}" -- node -e \
     'if (process.versions.node !== process.env.EXPECTED_NODE_VERSION) process.exit(1)'
 done
+
+export NODE_24_ROOT="${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}"
+test "$(readlink -f "$(command -v node)")" = "${NODE_24_ROOT}/bin/node"
+test "$(node --version)" = "v${NODE_24_VERSION}"
 
 cat >/tmp/mise-go-smoke.go <<'GO'
 package main
@@ -227,7 +231,7 @@ jq -n \
   --arg mise_version "${MISE_VERSION#v}" \
   --arg mise_sha256 "$(sha256sum /usr/local/bin/mise | awk '{print $1}')" \
   --arg root "${TOOLCHAIN_DATA_DIR}" \
-  --arg node20 "${NODE_20_VERSION}" \
+  --arg node22 "${NODE_22_VERSION}" \
   --arg node24 "${NODE_24_VERSION}" \
   --arg go124 "${GO_124_VERSION}" \
   --arg go125 "${GO_125_VERSION}" \
@@ -251,7 +255,7 @@ jq -n \
       executable_sha256: $mise_sha256
     },
     toolchains: [
-      tool("node"; $node20; "bin/node"),
+      tool("node"; $node22; "bin/node"),
       tool("node"; $node24; "bin/node"),
       tool("go"; $go124; "bin/go"),
       tool("go"; $go125; "bin/go"),
@@ -261,7 +265,7 @@ jq -n \
   }' \
   < <(
     sha256sum \
-      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_20_VERSION}/bin/node" \
+      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_22_VERSION}/bin/node" \
       "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}/bin/node" \
       "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_124_VERSION}/bin/go" \
       "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_125_VERSION}/bin/go" \
@@ -295,7 +299,7 @@ mark_complete() {
   test ! -s "${marker}"
 }
 
-mark_complete node "${NODE_20_VERSION}"
+mark_complete node "${NODE_22_VERSION}"
 mark_complete node "${NODE_24_VERSION}"
 mark_complete go "${GO_124_VERSION}"
 mark_complete go "${GO_125_VERSION}"

--- a/common/install-mise-toolchains.sh
+++ b/common/install-mise-toolchains.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+: "${MISE_VERSION:?}"
+: "${NODE_20_VERSION:?}"
+: "${NODE_24_VERSION:?}"
+
+export DEBIAN_ARCH="$(dpkg --print-architecture)"
+export TOOLCACHE_ARCH=x64
+if [ "${DEBIAN_ARCH}" = "arm64" ]; then
+  TOOLCACHE_ARCH=arm64
+fi
+
+test "$(mise --version | awk '{print $1}')" = "${MISE_VERSION#v}"
+
+export TOOLCHAIN_DATA_DIR=/opt/buildkite/mise-toolchains
+
+canonical_mise() {
+  MISE_DATA_DIR="${TOOLCHAIN_DATA_DIR}" \
+    MISE_CONFIG_DIR=/tmp/mise-config \
+    MISE_CACHE_DIR=/tmp/mise-cache \
+    MISE_RUBY_COMPILE=false \
+    mise "$@"
+}
+
+export GO_124_VERSION="$(canonical_mise latest go@1.24)"
+export GO_125_VERSION="$(canonical_mise latest go@1.25)"
+export GO_126_VERSION="$(canonical_mise latest go@1.26)"
+
+[[ "${GO_124_VERSION}" =~ ^1\.24\.[0-9]+$ ]]
+[[ "${GO_125_VERSION}" =~ ^1\.25\.[0-9]+$ ]]
+[[ "${GO_126_VERSION}" =~ ^1\.26\.[0-9]+$ ]]
+
+# Resolve the newest stable Ruby with precompiled assets for both Linux
+# architectures. An ephemeral lockfile selects its exact jdx/ruby build
+# revision without relying on the anonymous GitHub API quota.
+export RUBY_VERSION=
+export RUBY_SOURCE_RELEASE=
+for candidate in $(curl --retry 3 --retry-all-errors -fsSL https://mise-versions.jdx.dev/ruby | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr); do
+  candidate_release=
+  revision=1
+  while true; do
+    if [ "${revision}" -gt 1000 ]; then
+      echo "Refusing to resolve more than 1000 jdx/ruby revisions for ${candidate}" >&2
+      exit 1
+    fi
+    release="${candidate}-${revision}"
+    status="$(curl --retry 3 --retry-all-errors -sSL \
+      -o /tmp/mise-ruby-candidate-release.json -w '%{http_code}' \
+      "https://mise-versions.jdx.dev/api/github/repos/jdx/ruby/releases/${release}")"
+    case "${status}" in
+      200)
+        if jq -e --arg version "${candidate}" --arg release "${release}" '
+          .tag_name == $release and
+          any(.assets[]; .name == ("ruby-" + $version + ".x86_64_linux.tar.gz") and (.digest | test("^sha256:[0-9a-f]{64}$"))) and
+          any(.assets[]; .name == ("ruby-" + $version + ".arm64_linux.tar.gz") and (.digest | test("^sha256:[0-9a-f]{64}$")))
+        ' /tmp/mise-ruby-candidate-release.json >/dev/null; then
+          mv /tmp/mise-ruby-candidate-release.json /tmp/mise-ruby-release.json
+          candidate_release="${release}"
+        fi
+        ;;
+      404) break ;;
+      *) echo "Failed to resolve ${release}: HTTP ${status}" >&2; exit 1 ;;
+    esac
+    revision=$((revision + 1))
+  done
+  if [ -n "${candidate_release}" ]; then
+    RUBY_VERSION="${candidate}"
+    RUBY_SOURCE_RELEASE="${candidate_release}"
+    break
+  fi
+done
+test -n "${RUBY_VERSION}"
+test -n "${RUBY_SOURCE_RELEASE}"
+
+export RUBY_X64_ASSET="ruby-${RUBY_VERSION}.x86_64_linux.tar.gz"
+export RUBY_ARM64_ASSET="ruby-${RUBY_VERSION}.arm64_linux.tar.gz"
+export RUBY_X64_URL="$(jq -r --arg asset "${RUBY_X64_ASSET}" '.assets[] | select(.name == $asset) | .browser_download_url' /tmp/mise-ruby-release.json)"
+export RUBY_ARM64_URL="$(jq -r --arg asset "${RUBY_ARM64_ASSET}" '.assets[] | select(.name == $asset) | .browser_download_url' /tmp/mise-ruby-release.json)"
+export RUBY_X64_SHA256="$(jq -r --arg asset "${RUBY_X64_ASSET}" '.assets[] | select(.name == $asset) | .digest' /tmp/mise-ruby-release.json)"
+export RUBY_ARM64_SHA256="$(jq -r --arg asset "${RUBY_ARM64_ASSET}" '.assets[] | select(.name == $asset) | .digest' /tmp/mise-ruby-release.json)"
+
+mkdir /tmp/mise-ruby-project
+cat >/tmp/mise-ruby-project/mise.toml <<TOML
+[tools]
+ruby = "${RUBY_VERSION}"
+
+[settings]
+lockfile = true
+ruby.compile = false
+TOML
+cat >/tmp/mise-ruby-project/mise.lock <<TOML
+[[tools.ruby]]
+version = "${RUBY_VERSION}"
+backend = "core:ruby"
+
+[tools.ruby.options]
+compile = "false"
+precompiled_url = "jdx/ruby"
+ruby_build_repo = "https://github.com/rbenv/ruby-build.git"
+ruby_install = "false"
+
+[tools.ruby."platforms.linux-x64"]
+url = "${RUBY_X64_URL}"
+checksum = "${RUBY_X64_SHA256}"
+
+[tools.ruby."platforms.linux-arm64"]
+url = "${RUBY_ARM64_URL}"
+checksum = "${RUBY_ARM64_SHA256}"
+TOML
+
+canonical_mise install "node@${NODE_20_VERSION}"
+canonical_mise install "node@${NODE_24_VERSION}"
+canonical_mise install "go@${GO_124_VERSION}"
+canonical_mise install "go@${GO_125_VERSION}"
+canonical_mise install "go@${GO_126_VERSION}"
+canonical_mise trust /tmp/mise-ruby-project/mise.toml
+(
+  cd /tmp/mise-ruby-project
+  export MISE_ALWAYS_KEEP_DOWNLOAD=1
+  canonical_mise install --locked
+)
+
+export RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_X64_ASSET}"
+export RUBY_ARCHIVE_SHA256="${RUBY_X64_SHA256#sha256:}"
+if [ "${DEBIAN_ARCH}" = "arm64" ]; then
+  RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_ARM64_ASSET}"
+  RUBY_ARCHIVE_SHA256="${RUBY_ARM64_SHA256#sha256:}"
+fi
+test -f "${RUBY_ARCHIVE}"
+test ! -L "${RUBY_ARCHIVE}"
+echo "${RUBY_ARCHIVE_SHA256}  ${RUBY_ARCHIVE}" | sha256sum --check
+rm -rf "${TOOLCHAIN_DATA_DIR}/downloads"
+
+register_tool() {
+  local mise_tool="$1"
+  local toolcache_tool="$2"
+  local version="$3"
+  local executable="$4"
+  local canonical_root="${TOOLCHAIN_DATA_DIR}/installs/${mise_tool}/${version}"
+  local mise_root="/mise/installs/${mise_tool}/${version}"
+  local toolcache_version_root="/opt/hostedtoolcache/${toolcache_tool}/${version}"
+  local toolcache_root="${toolcache_version_root}/${TOOLCACHE_ARCH}"
+
+  test -d "${canonical_root}"
+  test ! -L "${canonical_root}"
+  test -f "${canonical_root}/${executable}"
+  test ! -L "${canonical_root}/${executable}"
+
+  mise link "${mise_tool}@${version}" "${canonical_root}"
+  test -L "${mise_root}"
+  test "$(readlink -f "${mise_root}")" = "${canonical_root}"
+
+  mkdir -p "${toolcache_version_root}"
+  ln -s "${canonical_root}" "${toolcache_root}"
+  test -L "${toolcache_root}"
+  test "$(readlink -f "${toolcache_root}")" = "${canonical_root}"
+}
+
+register_tool node node "${NODE_20_VERSION}" bin/node
+register_tool node node "${NODE_24_VERSION}" bin/node
+register_tool go go "${GO_124_VERSION}" bin/go
+register_tool go go "${GO_125_VERSION}" bin/go
+register_tool go go "${GO_126_VERSION}" bin/go
+register_tool ruby Ruby "${RUBY_VERSION}" bin/ruby
+
+test ! -e /mise/bin/mise
+
+for version in "${NODE_20_VERSION}" "${NODE_24_VERSION}"; do
+  canonical_root="${TOOLCHAIN_DATA_DIR}/installs/node/${version}"
+  test "$(readlink -f "$(mise where "node@${version}")")" = "${canonical_root}"
+  test "$(mise exec "node@${version}" -- node --version)" = "v${version}"
+  EXPECTED_NODE_VERSION="${version}" mise exec "node@${version}" -- node -e \
+    'if (process.versions.node !== process.env.EXPECTED_NODE_VERSION) process.exit(1)'
+done
+
+cat >/tmp/mise-go-smoke.go <<'GO'
+package main
+
+import "fmt"
+
+func main() { fmt.Print("mise-go-ok") }
+GO
+
+for version in "${GO_124_VERSION}" "${GO_125_VERSION}" "${GO_126_VERSION}"; do
+  canonical_root="${TOOLCHAIN_DATA_DIR}/installs/go/${version}"
+  test "$(readlink -f "$(mise where "go@${version}")")" = "${canonical_root}"
+  test "$(mise exec "go@${version}" -- go env GOVERSION)" = "go${version}"
+  test "$(GOCACHE=/tmp/mise-go-build-cache GOTELEMETRY=off \
+    mise exec "go@${version}" -- go run /tmp/mise-go-smoke.go)" = mise-go-ok
+done
+
+export RUBY_ROOT="${TOOLCHAIN_DATA_DIR}/installs/ruby/${RUBY_VERSION}"
+test "$(readlink -f "$(mise where "ruby@${RUBY_VERSION}")")" = "${RUBY_ROOT}"
+EXPECTED_RUBY_VERSION="${RUBY_VERSION}" EXPECTED_RUBY_ROOT="${RUBY_ROOT}" \
+  mise exec "ruby@${RUBY_VERSION}" -- ruby -ropenssl -rrbconfig -e \
+  'abort unless RUBY_VERSION == ENV.fetch("EXPECTED_RUBY_VERSION"); abort unless File.realpath(RbConfig::CONFIG.fetch("prefix")) == ENV.fetch("EXPECTED_RUBY_ROOT")'
+mise exec "ruby@${RUBY_VERSION}" -- gem --version
+mise exec "ruby@${RUBY_VERSION}" -- bundle --version
+
+mkdir /tmp/mise-ruby-native-extension
+cat >/tmp/mise-ruby-native-extension/extconf.rb <<'RUBY'
+require "mkmf"
+create_makefile("mise_image_smoke")
+RUBY
+cat >/tmp/mise-ruby-native-extension/mise_image_smoke.c <<'C'
+#include "ruby.h"
+
+static VALUE ok(VALUE self) { return Qtrue; }
+
+void Init_mise_image_smoke(void) {
+  VALUE module = rb_define_module("MiseImageSmoke");
+  rb_define_singleton_method(module, "ok?", ok, 0);
+}
+C
+pushd /tmp/mise-ruby-native-extension
+mise exec "ruby@${RUBY_VERSION}" -- ruby extconf.rb
+make
+mise exec "ruby@${RUBY_VERSION}" -- ruby -I. -rmise_image_smoke -e \
+  'abort unless MiseImageSmoke.ok?'
+popd
+
+jq -n \
+  --arg architecture "${DEBIAN_ARCH}" \
+  --arg toolcache_architecture "${TOOLCACHE_ARCH}" \
+  --arg mise_version "${MISE_VERSION#v}" \
+  --arg mise_sha256 "$(sha256sum /usr/local/bin/mise | awk '{print $1}')" \
+  --arg root "${TOOLCHAIN_DATA_DIR}" \
+  --arg node20 "${NODE_20_VERSION}" \
+  --arg node24 "${NODE_24_VERSION}" \
+  --arg go124 "${GO_124_VERSION}" \
+  --arg go125 "${GO_125_VERSION}" \
+  --arg go126 "${GO_126_VERSION}" \
+  --arg ruby "${RUBY_VERSION}" \
+  --arg ruby_source_release "${RUBY_SOURCE_RELEASE}" \
+  'def tool($name; $version; $executable): {
+    tool: $name,
+    version: $version,
+    canonical_root: ($root + "/installs/" + $name + "/" + $version),
+    executable: ($root + "/installs/" + $name + "/" + $version + "/" + $executable)
+  } | .executable_sha256 = (input);
+  {
+    schema_version: 1,
+    architecture: $architecture,
+    toolcache_architecture: $toolcache_architecture,
+    canonical_data_dir: $root,
+    mise: {
+      version: $mise_version,
+      executable: "/usr/local/bin/mise",
+      executable_sha256: $mise_sha256
+    },
+    toolchains: [
+      tool("node"; $node20; "bin/node"),
+      tool("node"; $node24; "bin/node"),
+      tool("go"; $go124; "bin/go"),
+      tool("go"; $go125; "bin/go"),
+      tool("go"; $go126; "bin/go"),
+      (tool("ruby"; $ruby; "bin/ruby") + {source_release: $ruby_source_release})
+    ]
+  }' \
+  < <(
+    sha256sum \
+      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_20_VERSION}/bin/node" \
+      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}/bin/node" \
+      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_124_VERSION}/bin/go" \
+      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_125_VERSION}/bin/go" \
+      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_126_VERSION}/bin/go" \
+      "${TOOLCHAIN_DATA_DIR}/installs/ruby/${RUBY_VERSION}/bin/ruby" |
+      awk '{print "\"" $1 "\""}'
+  ) >"${TOOLCHAIN_DATA_DIR}/manifest.json"
+
+test "$(jq -r '.mise.version' "${TOOLCHAIN_DATA_DIR}/manifest.json")" = "$(mise --version | awk '{print $1}')"
+while IFS=$'\t' read -r tool version canonical_root executable executable_sha256; do
+  test -d "${canonical_root}"
+  test ! -L "${canonical_root}"
+  test -f "${executable}"
+  test ! -L "${executable}"
+  test "$(sha256sum "${executable}" | awk '{print $1}')" = "${executable_sha256}"
+  case "${tool}" in
+    node) reported_version="$("${executable}" --version)"; reported_version="${reported_version#v}" ;;
+    go) reported_version="$("${executable}" env GOVERSION)"; reported_version="${reported_version#go}" ;;
+    ruby) reported_version="$("${executable}" -e 'print RUBY_VERSION')" ;;
+  esac
+  test "${reported_version}" = "${version}"
+done < <(jq -r '.toolchains[] | [.tool, .version, .canonical_root, .executable, .executable_sha256] | @tsv' "${TOOLCHAIN_DATA_DIR}/manifest.json")
+
+mark_complete() {
+  local toolcache_tool="$1"
+  local version="$2"
+  local marker="/opt/hostedtoolcache/${toolcache_tool}/${version}/${TOOLCACHE_ARCH}.complete"
+  test ! -e "${marker}"
+  : >"${marker}"
+  test -f "${marker}"
+  test ! -s "${marker}"
+}
+
+mark_complete node "${NODE_20_VERSION}"
+mark_complete node "${NODE_24_VERSION}"
+mark_complete go "${GO_124_VERSION}"
+mark_complete go "${GO_125_VERSION}"
+mark_complete go "${GO_126_VERSION}"
+mark_complete Ruby "${RUBY_VERSION}"
+
+rm -rf /mise/cache /tmp/mise-cache /tmp/mise-config \
+  /tmp/mise-go-build-cache /tmp/mise-go-smoke.go \
+  /tmp/mise-ruby-native-extension /tmp/mise-ruby-project \
+  /tmp/mise-ruby-release.json /tmp/node-compile-cache \
+  /tmp/mise-ruby-candidate-release.json

--- a/common/install-mise-toolchains.sh
+++ b/common/install-mise-toolchains.sh
@@ -176,8 +176,9 @@ for version in "${NODE_22_VERSION}" "${NODE_24_VERSION}"; do
 done
 
 export NODE_24_ROOT="${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}"
-test "$(readlink -f "$(command -v node)")" = "${NODE_24_ROOT}/bin/node"
-test "$(node --version)" = "v${NODE_24_VERSION}"
+test -f "${NODE_24_ROOT}/bin/node"
+test ! -L "${NODE_24_ROOT}/bin/node"
+test "$("${NODE_24_ROOT}/bin/node" --version)" = "v${NODE_24_VERSION}"
 
 cat >/tmp/mise-go-smoke.go <<'GO'
 package main

--- a/ubuntu-jammy-hosted-toolchains/README.md
+++ b/ubuntu-jammy-hosted-toolchains/README.md
@@ -1,0 +1,6 @@
+# ubuntu-jammy-hosted-toolchains
+
+This variant has no separate Dockerfile. It is built from the `toolchains`
+target in [`../ubuntu-jammy-hosted/Dockerfile`](../ubuntu-jammy-hosted/Dockerfile),
+selected by
+[`build-docker-base-image.sh`](../.buildkite/steps/build-docker-base-image.sh).

--- a/ubuntu-jammy-hosted/Dockerfile
+++ b/ubuntu-jammy-hosted/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 ARG MISE_VERSION=v2026.8.3
-ARG NODE_20_VERSION=20.20.2
+ARG NODE_22_VERSION=22.23.2
 ARG NODE_24_VERSION=24.18.0
 
 FROM public.ecr.aws/ubuntu/ubuntu:22.04 AS base
@@ -9,6 +9,7 @@ FROM public.ecr.aws/ubuntu/ubuntu:22.04 AS base
 ARG BAZELISK_VERSION=v1.29.0
 ARG BK_CLI_VERSION=3.40.0
 ARG MISE_VERSION
+ARG NODE_24_VERSION
 ARG MISE_SHA256_AMD64=66585ac496c10bf6fbf13272e3e550c1813aed0e1cb780b9bb73c1751de49289
 ARG MISE_SHA256_ARM64=a5bdab52367ecca6c253b60f74d85f8cefe51f613e3b7fcec7b7a5f1dc1bbb41
 
@@ -19,7 +20,7 @@ ENV MISE_DATA_DIR="/mise"
 ENV MISE_CONFIG_DIR="/mise"
 ENV MISE_CACHE_DIR="/mise/cache"
 ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
-ENV PATH="/mise/shims:$PATH"
+ENV PATH="/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}/bin:/mise/shims:$PATH"
 
 ARG TARGETARCH
 
@@ -91,6 +92,19 @@ echo "${MISE_SHA256}  /usr/local/bin/mise" | sha256sum --check
 chmod 0755 /usr/local/bin/mise
 test "$(mise --version | awk '{print $1}')" = "${MISE_VERSION#v}"
 
+# Install the image's default Node at its permanent mise-owned root. The
+# toolchains target registers this same directory with mise and setup-node.
+export NODE_24_ROOT="/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}"
+MISE_DATA_DIR=/opt/buildkite/mise-toolchains \
+  MISE_CONFIG_DIR=/tmp/mise-config \
+  MISE_CACHE_DIR=/tmp/mise-cache \
+  mise install "node@${NODE_24_VERSION}"
+test -d "${NODE_24_ROOT}"
+test ! -L "${NODE_24_ROOT}"
+test "$(readlink -f "$(command -v node)")" = "${NODE_24_ROOT}/bin/node"
+test "$(node --version)" = "v${NODE_24_VERSION}"
+rm -rf /tmp/mise-cache /tmp/mise-config
+
 # install aws-cli
 curl https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip -o /tmp/awscliv2.zip
 unzip -q /tmp/awscliv2.zip -d /opt
@@ -104,14 +118,7 @@ echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.clou
 apt-get update && apt-get install -y google-cloud-cli
 gcloud --version
 
-# install nodejs
-git clone https://github.com/tj/n /usr/src/n
-pushd /usr/src/n
-make install
-popd
-n lts
-rm -rf /usr/src/n /tmp/*
-node --version
+rm -rf /tmp/*
 
 ln -s /usr/bin/tini /usr/sbin/tini
 
@@ -124,7 +131,7 @@ BASH
 FROM base AS toolchains
 
 ARG MISE_VERSION
-ARG NODE_20_VERSION
+ARG NODE_22_VERSION
 ARG NODE_24_VERSION
 
 RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \

--- a/ubuntu-jammy-hosted/Dockerfile
+++ b/ubuntu-jammy-hosted/Dockerfile
@@ -1,14 +1,16 @@
 # syntax=docker/dockerfile:1.4
 
+ARG MISE_VERSION=v2026.8.3
+ARG NODE_20_VERSION=20.20.2
+ARG NODE_24_VERSION=24.18.0
+
 FROM public.ecr.aws/ubuntu/ubuntu:22.04 AS base
 
 ARG BAZELISK_VERSION=v1.29.0
 ARG BK_CLI_VERSION=3.40.0
-ARG MISE_VERSION=v2026.8.3
+ARG MISE_VERSION
 ARG MISE_SHA256_AMD64=66585ac496c10bf6fbf13272e3e550c1813aed0e1cb780b9bb73c1751de49289
 ARG MISE_SHA256_ARM64=a5bdab52367ecca6c253b60f74d85f8cefe51f613e3b7fcec7b7a5f1dc1bbb41
-ARG NODE_20_VERSION=20.20.2
-ARG NODE_24_VERSION=24.18.0
 
 ENV LC_CTYPE="C.UTF-8"
 
@@ -77,312 +79,17 @@ curl -fLo /tmp/bk.deb https://github.com/buildkite/cli/releases/download/v${BK_C
 dpkg -i /tmp/bk.deb
 rm -f /tmp/bk.deb
 
-# install a pinned mise binary and preload common Hosted toolchains
+# install pinned mise binary
 export MISE_ARCH=x64
 export MISE_SHA256=${MISE_SHA256_AMD64}
-export TOOLCACHE_ARCH=x64
 if [ "${DEBIAN_ARCH}" = "arm64" ]; then
-  export MISE_ARCH=arm64
-  export MISE_SHA256=${MISE_SHA256_ARM64}
-  export TOOLCACHE_ARCH=arm64
+  MISE_ARCH=arm64
+  MISE_SHA256=${MISE_SHA256_ARM64}
 fi
-
 curl -fLo /usr/local/bin/mise https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-${MISE_ARCH}
 echo "${MISE_SHA256}  /usr/local/bin/mise" | sha256sum --check
 chmod 0755 /usr/local/bin/mise
 test "$(mise --version | awk '{print $1}')" = "${MISE_VERSION#v}"
-
-export TOOLCHAIN_DATA_DIR=/opt/buildkite/mise-toolchains
-
-canonical_mise() {
-  MISE_DATA_DIR="${TOOLCHAIN_DATA_DIR}" \
-    MISE_CONFIG_DIR=/tmp/mise-config \
-    MISE_CACHE_DIR=/tmp/mise-cache \
-    MISE_RUBY_COMPILE=false \
-    mise "$@"
-}
-
-export GO_124_VERSION="$(canonical_mise latest go@1.24)"
-export GO_125_VERSION="$(canonical_mise latest go@1.25)"
-export GO_126_VERSION="$(canonical_mise latest go@1.26)"
-
-[[ "${GO_124_VERSION}" =~ ^1\.24\.[0-9]+$ ]]
-[[ "${GO_125_VERSION}" =~ ^1\.25\.[0-9]+$ ]]
-[[ "${GO_126_VERSION}" =~ ^1\.26\.[0-9]+$ ]]
-
-# Resolve the newest stable Ruby with precompiled assets for both Linux
-# architectures. An ephemeral lockfile selects its exact jdx/ruby build
-# revision without relying on the anonymous GitHub API quota.
-export RUBY_VERSION=
-export RUBY_SOURCE_RELEASE=
-for candidate in $(curl --retry 3 --retry-all-errors -fsSL https://mise-versions.jdx.dev/ruby | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr); do
-  candidate_release=
-  revision=1
-  while true; do
-    if [ "${revision}" -gt 1000 ]; then
-      echo "Refusing to resolve more than 1000 jdx/ruby revisions for ${candidate}" >&2
-      exit 1
-    fi
-    release="${candidate}-${revision}"
-    status="$(curl --retry 3 --retry-all-errors -sSL \
-      -o /tmp/mise-ruby-candidate-release.json -w '%{http_code}' \
-      "https://mise-versions.jdx.dev/api/github/repos/jdx/ruby/releases/${release}")"
-    case "${status}" in
-      200)
-        if jq -e --arg version "${candidate}" --arg release "${release}" '
-          .tag_name == $release and
-          any(.assets[]; .name == ("ruby-" + $version + ".x86_64_linux.tar.gz") and (.digest | test("^sha256:[0-9a-f]{64}$"))) and
-          any(.assets[]; .name == ("ruby-" + $version + ".arm64_linux.tar.gz") and (.digest | test("^sha256:[0-9a-f]{64}$")))
-        ' /tmp/mise-ruby-candidate-release.json >/dev/null; then
-          mv /tmp/mise-ruby-candidate-release.json /tmp/mise-ruby-release.json
-          candidate_release="${release}"
-        fi
-        ;;
-      404) break ;;
-      *) echo "Failed to resolve ${release}: HTTP ${status}" >&2; exit 1 ;;
-    esac
-    revision=$((revision + 1))
-  done
-  if [ -n "${candidate_release}" ]; then
-    RUBY_VERSION="${candidate}"
-    RUBY_SOURCE_RELEASE="${candidate_release}"
-    break
-  fi
-done
-test -n "${RUBY_VERSION}"
-test -n "${RUBY_SOURCE_RELEASE}"
-
-export RUBY_X64_ASSET="ruby-${RUBY_VERSION}.x86_64_linux.tar.gz"
-export RUBY_ARM64_ASSET="ruby-${RUBY_VERSION}.arm64_linux.tar.gz"
-export RUBY_X64_URL="$(jq -r --arg asset "${RUBY_X64_ASSET}" '.assets[] | select(.name == $asset) | .browser_download_url' /tmp/mise-ruby-release.json)"
-export RUBY_ARM64_URL="$(jq -r --arg asset "${RUBY_ARM64_ASSET}" '.assets[] | select(.name == $asset) | .browser_download_url' /tmp/mise-ruby-release.json)"
-export RUBY_X64_SHA256="$(jq -r --arg asset "${RUBY_X64_ASSET}" '.assets[] | select(.name == $asset) | .digest' /tmp/mise-ruby-release.json)"
-export RUBY_ARM64_SHA256="$(jq -r --arg asset "${RUBY_ARM64_ASSET}" '.assets[] | select(.name == $asset) | .digest' /tmp/mise-ruby-release.json)"
-
-mkdir /tmp/mise-ruby-project
-cat >/tmp/mise-ruby-project/mise.toml <<TOML
-[tools]
-ruby = "${RUBY_VERSION}"
-
-[settings]
-lockfile = true
-ruby.compile = false
-TOML
-cat >/tmp/mise-ruby-project/mise.lock <<TOML
-[[tools.ruby]]
-version = "${RUBY_VERSION}"
-backend = "core:ruby"
-
-[tools.ruby.options]
-compile = "false"
-precompiled_url = "jdx/ruby"
-ruby_build_repo = "https://github.com/rbenv/ruby-build.git"
-ruby_install = "false"
-
-[tools.ruby."platforms.linux-x64"]
-url = "${RUBY_X64_URL}"
-checksum = "${RUBY_X64_SHA256}"
-
-[tools.ruby."platforms.linux-arm64"]
-url = "${RUBY_ARM64_URL}"
-checksum = "${RUBY_ARM64_SHA256}"
-TOML
-
-canonical_mise install "node@${NODE_20_VERSION}"
-canonical_mise install "node@${NODE_24_VERSION}"
-canonical_mise install "go@${GO_124_VERSION}"
-canonical_mise install "go@${GO_125_VERSION}"
-canonical_mise install "go@${GO_126_VERSION}"
-canonical_mise trust /tmp/mise-ruby-project/mise.toml
-(
-  cd /tmp/mise-ruby-project
-  export MISE_ALWAYS_KEEP_DOWNLOAD=1
-  canonical_mise install --locked
-)
-
-export RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_X64_ASSET}"
-export RUBY_ARCHIVE_SHA256="${RUBY_X64_SHA256#sha256:}"
-if [ "${DEBIAN_ARCH}" = "arm64" ]; then
-  RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_ARM64_ASSET}"
-  RUBY_ARCHIVE_SHA256="${RUBY_ARM64_SHA256#sha256:}"
-fi
-test -f "${RUBY_ARCHIVE}"
-test ! -L "${RUBY_ARCHIVE}"
-echo "${RUBY_ARCHIVE_SHA256}  ${RUBY_ARCHIVE}" | sha256sum --check
-rm -rf "${TOOLCHAIN_DATA_DIR}/downloads"
-
-register_tool() {
-  local mise_tool="$1"
-  local toolcache_tool="$2"
-  local version="$3"
-  local executable="$4"
-  local canonical_root="${TOOLCHAIN_DATA_DIR}/installs/${mise_tool}/${version}"
-  local mise_root="/mise/installs/${mise_tool}/${version}"
-  local toolcache_version_root="/opt/hostedtoolcache/${toolcache_tool}/${version}"
-  local toolcache_root="${toolcache_version_root}/${TOOLCACHE_ARCH}"
-
-  test -d "${canonical_root}"
-  test ! -L "${canonical_root}"
-  test -f "${canonical_root}/${executable}"
-  test ! -L "${canonical_root}/${executable}"
-
-  mise link "${mise_tool}@${version}" "${canonical_root}"
-  test -L "${mise_root}"
-  test "$(readlink -f "${mise_root}")" = "${canonical_root}"
-
-  mkdir -p "${toolcache_version_root}"
-  ln -s "${canonical_root}" "${toolcache_root}"
-  test -L "${toolcache_root}"
-  test "$(readlink -f "${toolcache_root}")" = "${canonical_root}"
-}
-
-register_tool node node "${NODE_20_VERSION}" bin/node
-register_tool node node "${NODE_24_VERSION}" bin/node
-register_tool go go "${GO_124_VERSION}" bin/go
-register_tool go go "${GO_125_VERSION}" bin/go
-register_tool go go "${GO_126_VERSION}" bin/go
-register_tool ruby Ruby "${RUBY_VERSION}" bin/ruby
-
-test ! -e /mise/bin/mise
-
-for version in "${NODE_20_VERSION}" "${NODE_24_VERSION}"; do
-  canonical_root="${TOOLCHAIN_DATA_DIR}/installs/node/${version}"
-  test "$(readlink -f "$(mise where "node@${version}")")" = "${canonical_root}"
-  test "$(mise exec "node@${version}" -- node --version)" = "v${version}"
-  EXPECTED_NODE_VERSION="${version}" mise exec "node@${version}" -- node -e \
-    'if (process.versions.node !== process.env.EXPECTED_NODE_VERSION) process.exit(1)'
-done
-
-cat >/tmp/mise-go-smoke.go <<'GO'
-package main
-
-import "fmt"
-
-func main() { fmt.Print("mise-go-ok") }
-GO
-
-for version in "${GO_124_VERSION}" "${GO_125_VERSION}" "${GO_126_VERSION}"; do
-  canonical_root="${TOOLCHAIN_DATA_DIR}/installs/go/${version}"
-  test "$(readlink -f "$(mise where "go@${version}")")" = "${canonical_root}"
-  test "$(mise exec "go@${version}" -- go env GOVERSION)" = "go${version}"
-  test "$(mise exec "go@${version}" -- go run /tmp/mise-go-smoke.go)" = mise-go-ok
-done
-
-export RUBY_ROOT="${TOOLCHAIN_DATA_DIR}/installs/ruby/${RUBY_VERSION}"
-test "$(readlink -f "$(mise where "ruby@${RUBY_VERSION}")")" = "${RUBY_ROOT}"
-EXPECTED_RUBY_VERSION="${RUBY_VERSION}" EXPECTED_RUBY_ROOT="${RUBY_ROOT}" \
-  mise exec "ruby@${RUBY_VERSION}" -- ruby -ropenssl -rrbconfig -e \
-  'abort unless RUBY_VERSION == ENV.fetch("EXPECTED_RUBY_VERSION"); abort unless File.realpath(RbConfig::CONFIG.fetch("prefix")) == ENV.fetch("EXPECTED_RUBY_ROOT")'
-mise exec "ruby@${RUBY_VERSION}" -- gem --version
-mise exec "ruby@${RUBY_VERSION}" -- bundle --version
-
-mkdir /tmp/mise-ruby-native-extension
-cat >/tmp/mise-ruby-native-extension/extconf.rb <<'RUBY'
-require "mkmf"
-create_makefile("mise_image_smoke")
-RUBY
-cat >/tmp/mise-ruby-native-extension/mise_image_smoke.c <<'C'
-#include "ruby.h"
-
-static VALUE ok(VALUE self) { return Qtrue; }
-
-void Init_mise_image_smoke(void) {
-  VALUE module = rb_define_module("MiseImageSmoke");
-  rb_define_singleton_method(module, "ok?", ok, 0);
-}
-C
-pushd /tmp/mise-ruby-native-extension
-mise exec "ruby@${RUBY_VERSION}" -- ruby extconf.rb
-make
-mise exec "ruby@${RUBY_VERSION}" -- ruby -I. -rmise_image_smoke -e \
-  'abort unless MiseImageSmoke.ok?'
-popd
-
-jq -n \
-  --arg architecture "${DEBIAN_ARCH}" \
-  --arg toolcache_architecture "${TOOLCACHE_ARCH}" \
-  --arg mise_version "${MISE_VERSION#v}" \
-  --arg mise_sha256 "$(sha256sum /usr/local/bin/mise | awk '{print $1}')" \
-  --arg root "${TOOLCHAIN_DATA_DIR}" \
-  --arg node20 "${NODE_20_VERSION}" \
-  --arg node24 "${NODE_24_VERSION}" \
-  --arg go124 "${GO_124_VERSION}" \
-  --arg go125 "${GO_125_VERSION}" \
-  --arg go126 "${GO_126_VERSION}" \
-  --arg ruby "${RUBY_VERSION}" \
-  --arg ruby_source_release "${RUBY_SOURCE_RELEASE}" \
-  'def tool($name; $version; $executable): {
-    tool: $name,
-    version: $version,
-    canonical_root: ($root + "/installs/" + $name + "/" + $version),
-    executable: ($root + "/installs/" + $name + "/" + $version + "/" + $executable)
-  } | .executable_sha256 = (input);
-  {
-    schema_version: 1,
-    architecture: $architecture,
-    toolcache_architecture: $toolcache_architecture,
-    canonical_data_dir: $root,
-    mise: {
-      version: $mise_version,
-      executable: "/usr/local/bin/mise",
-      executable_sha256: $mise_sha256
-    },
-    toolchains: [
-      tool("node"; $node20; "bin/node"),
-      tool("node"; $node24; "bin/node"),
-      tool("go"; $go124; "bin/go"),
-      tool("go"; $go125; "bin/go"),
-      tool("go"; $go126; "bin/go"),
-      (tool("ruby"; $ruby; "bin/ruby") + {source_release: $ruby_source_release})
-    ]
-  }' \
-  < <(
-    sha256sum \
-      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_20_VERSION}/bin/node" \
-      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}/bin/node" \
-      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_124_VERSION}/bin/go" \
-      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_125_VERSION}/bin/go" \
-      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_126_VERSION}/bin/go" \
-      "${TOOLCHAIN_DATA_DIR}/installs/ruby/${RUBY_VERSION}/bin/ruby" |
-      awk '{print "\"" $1 "\""}'
-  ) >"${TOOLCHAIN_DATA_DIR}/manifest.json"
-
-test "$(jq -r '.mise.version' "${TOOLCHAIN_DATA_DIR}/manifest.json")" = "$(mise --version | awk '{print $1}')"
-while IFS=$'\t' read -r tool version canonical_root executable executable_sha256; do
-  test -d "${canonical_root}"
-  test ! -L "${canonical_root}"
-  test -f "${executable}"
-  test ! -L "${executable}"
-  test "$(sha256sum "${executable}" | awk '{print $1}')" = "${executable_sha256}"
-  case "${tool}" in
-    node) reported_version="$("${executable}" --version)"; reported_version="${reported_version#v}" ;;
-    go) reported_version="$("${executable}" env GOVERSION)"; reported_version="${reported_version#go}" ;;
-    ruby) reported_version="$("${executable}" -e 'print RUBY_VERSION')" ;;
-  esac
-  test "${reported_version}" = "${version}"
-done < <(jq -r '.toolchains[] | [.tool, .version, .canonical_root, .executable, .executable_sha256] | @tsv' "${TOOLCHAIN_DATA_DIR}/manifest.json")
-
-mark_complete() {
-  local toolcache_tool="$1"
-  local version="$2"
-  local marker="/opt/hostedtoolcache/${toolcache_tool}/${version}/${TOOLCACHE_ARCH}.complete"
-  test ! -e "${marker}"
-  : >"${marker}"
-  test -f "${marker}"
-  test ! -s "${marker}"
-}
-
-mark_complete node "${NODE_20_VERSION}"
-mark_complete node "${NODE_24_VERSION}"
-mark_complete go "${GO_124_VERSION}"
-mark_complete go "${GO_125_VERSION}"
-mark_complete go "${GO_126_VERSION}"
-mark_complete Ruby "${RUBY_VERSION}"
-
-rm -rf /mise/cache /tmp/mise-cache /tmp/mise-config \
-  /tmp/mise-go-smoke.go /tmp/mise-ruby-native-extension \
-  /tmp/mise-ruby-project /tmp/mise-ruby-release.json \
-  /tmp/mise-ruby-candidate-release.json
 
 # install aws-cli
 curl https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip -o /tmp/awscliv2.zip
@@ -414,7 +121,21 @@ apt clean all
 rm -rf /var/lib/apt/lists/*
 BASH
 
-FROM base
+FROM base AS toolchains
+
+ARG MISE_VERSION
+ARG NODE_20_VERSION
+ARG NODE_24_VERSION
+
+RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \
+  bash /tmp/install-mise-toolchains.sh
+
+WORKDIR /root
+USER root
+
+# Keep the normal Hosted tag slim; the opt-in variant explicitly builds the
+# toolchains target above.
+FROM base AS hosted
 
 WORKDIR /root
 USER root

--- a/ubuntu-jammy-hosted/Dockerfile
+++ b/ubuntu-jammy-hosted/Dockerfile
@@ -27,6 +27,7 @@ ARG TARGETARCH
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-${TARGETARCH},sharing=locked \
 --mount=type=cache,target=/var/lib/apt,id=apt-lib-${TARGETARCH},sharing=locked \
 --mount=type=cache,target=/var/cache/debconf,id=debconf-${TARGETARCH},sharing=locked \
+--mount=type=bind,source=common/install-mise-default-node.sh,target=/install-mise-default-node.sh \
 <<BASH
 #!/usr/bin/env bash
 
@@ -80,30 +81,7 @@ curl -fLo /tmp/bk.deb https://github.com/buildkite/cli/releases/download/v${BK_C
 dpkg -i /tmp/bk.deb
 rm -f /tmp/bk.deb
 
-# install pinned mise binary
-export MISE_ARCH=x64
-export MISE_SHA256=${MISE_SHA256_AMD64}
-if [ "${DEBIAN_ARCH}" = "arm64" ]; then
-  MISE_ARCH=arm64
-  MISE_SHA256=${MISE_SHA256_ARM64}
-fi
-curl -fLo /usr/local/bin/mise https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-${MISE_ARCH}
-echo "${MISE_SHA256}  /usr/local/bin/mise" | sha256sum --check
-chmod 0755 /usr/local/bin/mise
-test "$(mise --version | awk '{print $1}')" = "${MISE_VERSION#v}"
-
-# Install the image's default Node at its permanent mise-owned root. The
-# toolchains target registers this same directory with mise and setup-node.
-export NODE_24_ROOT="/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}"
-MISE_DATA_DIR=/opt/buildkite/mise-toolchains \
-  MISE_CONFIG_DIR=/tmp/mise-config \
-  MISE_CACHE_DIR=/tmp/mise-cache \
-  mise install "node@${NODE_24_VERSION}"
-test -d "${NODE_24_ROOT}"
-test ! -L "${NODE_24_ROOT}"
-test "$(readlink -f "$(command -v node)")" = "${NODE_24_ROOT}/bin/node"
-test "$(node --version)" = "v${NODE_24_VERSION}"
-rm -rf /tmp/mise-cache /tmp/mise-config
+bash /install-mise-default-node.sh
 
 # install aws-cli
 curl https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip -o /tmp/awscliv2.zip

--- a/ubuntu-jammy-hosted/Dockerfile
+++ b/ubuntu-jammy-hosted/Dockerfile
@@ -4,6 +4,11 @@ FROM public.ecr.aws/ubuntu/ubuntu:22.04 AS base
 
 ARG BAZELISK_VERSION=v1.29.0
 ARG BK_CLI_VERSION=3.40.0
+ARG MISE_VERSION=v2026.8.3
+ARG MISE_SHA256_AMD64=66585ac496c10bf6fbf13272e3e550c1813aed0e1cb780b9bb73c1751de49289
+ARG MISE_SHA256_ARM64=a5bdab52367ecca6c253b60f74d85f8cefe51f613e3b7fcec7b7a5f1dc1bbb41
+ARG NODE_20_VERSION=20.20.2
+ARG NODE_24_VERSION=24.18.0
 
 ENV LC_CTYPE="C.UTF-8"
 
@@ -72,8 +77,312 @@ curl -fLo /tmp/bk.deb https://github.com/buildkite/cli/releases/download/v${BK_C
 dpkg -i /tmp/bk.deb
 rm -f /tmp/bk.deb
 
-# install mise
-curl -fsL https://mise.run | bash
+# install a pinned mise binary and preload common Hosted toolchains
+export MISE_ARCH=x64
+export MISE_SHA256=${MISE_SHA256_AMD64}
+export TOOLCACHE_ARCH=x64
+if [ "${DEBIAN_ARCH}" = "arm64" ]; then
+  export MISE_ARCH=arm64
+  export MISE_SHA256=${MISE_SHA256_ARM64}
+  export TOOLCACHE_ARCH=arm64
+fi
+
+curl -fLo /usr/local/bin/mise https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-${MISE_ARCH}
+echo "${MISE_SHA256}  /usr/local/bin/mise" | sha256sum --check
+chmod 0755 /usr/local/bin/mise
+test "$(mise --version | awk '{print $1}')" = "${MISE_VERSION#v}"
+
+export TOOLCHAIN_DATA_DIR=/opt/buildkite/mise-toolchains
+
+canonical_mise() {
+  MISE_DATA_DIR="${TOOLCHAIN_DATA_DIR}" \
+    MISE_CONFIG_DIR=/tmp/mise-config \
+    MISE_CACHE_DIR=/tmp/mise-cache \
+    MISE_RUBY_COMPILE=false \
+    mise "$@"
+}
+
+export GO_124_VERSION="$(canonical_mise latest go@1.24)"
+export GO_125_VERSION="$(canonical_mise latest go@1.25)"
+export GO_126_VERSION="$(canonical_mise latest go@1.26)"
+
+[[ "${GO_124_VERSION}" =~ ^1\.24\.[0-9]+$ ]]
+[[ "${GO_125_VERSION}" =~ ^1\.25\.[0-9]+$ ]]
+[[ "${GO_126_VERSION}" =~ ^1\.26\.[0-9]+$ ]]
+
+# Resolve the newest stable Ruby with precompiled assets for both Linux
+# architectures. An ephemeral lockfile selects its exact jdx/ruby build
+# revision without relying on the anonymous GitHub API quota.
+export RUBY_VERSION=
+export RUBY_SOURCE_RELEASE=
+for candidate in $(curl --retry 3 --retry-all-errors -fsSL https://mise-versions.jdx.dev/ruby | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr); do
+  candidate_release=
+  revision=1
+  while true; do
+    if [ "${revision}" -gt 1000 ]; then
+      echo "Refusing to resolve more than 1000 jdx/ruby revisions for ${candidate}" >&2
+      exit 1
+    fi
+    release="${candidate}-${revision}"
+    status="$(curl --retry 3 --retry-all-errors -sSL \
+      -o /tmp/mise-ruby-candidate-release.json -w '%{http_code}' \
+      "https://mise-versions.jdx.dev/api/github/repos/jdx/ruby/releases/${release}")"
+    case "${status}" in
+      200)
+        if jq -e --arg version "${candidate}" --arg release "${release}" '
+          .tag_name == $release and
+          any(.assets[]; .name == ("ruby-" + $version + ".x86_64_linux.tar.gz") and (.digest | test("^sha256:[0-9a-f]{64}$"))) and
+          any(.assets[]; .name == ("ruby-" + $version + ".arm64_linux.tar.gz") and (.digest | test("^sha256:[0-9a-f]{64}$")))
+        ' /tmp/mise-ruby-candidate-release.json >/dev/null; then
+          mv /tmp/mise-ruby-candidate-release.json /tmp/mise-ruby-release.json
+          candidate_release="${release}"
+        fi
+        ;;
+      404) break ;;
+      *) echo "Failed to resolve ${release}: HTTP ${status}" >&2; exit 1 ;;
+    esac
+    revision=$((revision + 1))
+  done
+  if [ -n "${candidate_release}" ]; then
+    RUBY_VERSION="${candidate}"
+    RUBY_SOURCE_RELEASE="${candidate_release}"
+    break
+  fi
+done
+test -n "${RUBY_VERSION}"
+test -n "${RUBY_SOURCE_RELEASE}"
+
+export RUBY_X64_ASSET="ruby-${RUBY_VERSION}.x86_64_linux.tar.gz"
+export RUBY_ARM64_ASSET="ruby-${RUBY_VERSION}.arm64_linux.tar.gz"
+export RUBY_X64_URL="$(jq -r --arg asset "${RUBY_X64_ASSET}" '.assets[] | select(.name == $asset) | .browser_download_url' /tmp/mise-ruby-release.json)"
+export RUBY_ARM64_URL="$(jq -r --arg asset "${RUBY_ARM64_ASSET}" '.assets[] | select(.name == $asset) | .browser_download_url' /tmp/mise-ruby-release.json)"
+export RUBY_X64_SHA256="$(jq -r --arg asset "${RUBY_X64_ASSET}" '.assets[] | select(.name == $asset) | .digest' /tmp/mise-ruby-release.json)"
+export RUBY_ARM64_SHA256="$(jq -r --arg asset "${RUBY_ARM64_ASSET}" '.assets[] | select(.name == $asset) | .digest' /tmp/mise-ruby-release.json)"
+
+mkdir /tmp/mise-ruby-project
+cat >/tmp/mise-ruby-project/mise.toml <<TOML
+[tools]
+ruby = "${RUBY_VERSION}"
+
+[settings]
+lockfile = true
+ruby.compile = false
+TOML
+cat >/tmp/mise-ruby-project/mise.lock <<TOML
+[[tools.ruby]]
+version = "${RUBY_VERSION}"
+backend = "core:ruby"
+
+[tools.ruby.options]
+compile = "false"
+precompiled_url = "jdx/ruby"
+ruby_build_repo = "https://github.com/rbenv/ruby-build.git"
+ruby_install = "false"
+
+[tools.ruby."platforms.linux-x64"]
+url = "${RUBY_X64_URL}"
+checksum = "${RUBY_X64_SHA256}"
+
+[tools.ruby."platforms.linux-arm64"]
+url = "${RUBY_ARM64_URL}"
+checksum = "${RUBY_ARM64_SHA256}"
+TOML
+
+canonical_mise install "node@${NODE_20_VERSION}"
+canonical_mise install "node@${NODE_24_VERSION}"
+canonical_mise install "go@${GO_124_VERSION}"
+canonical_mise install "go@${GO_125_VERSION}"
+canonical_mise install "go@${GO_126_VERSION}"
+canonical_mise trust /tmp/mise-ruby-project/mise.toml
+(
+  cd /tmp/mise-ruby-project
+  export MISE_ALWAYS_KEEP_DOWNLOAD=1
+  canonical_mise install --locked
+)
+
+export RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_X64_ASSET}"
+export RUBY_ARCHIVE_SHA256="${RUBY_X64_SHA256#sha256:}"
+if [ "${DEBIAN_ARCH}" = "arm64" ]; then
+  RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_ARM64_ASSET}"
+  RUBY_ARCHIVE_SHA256="${RUBY_ARM64_SHA256#sha256:}"
+fi
+test -f "${RUBY_ARCHIVE}"
+test ! -L "${RUBY_ARCHIVE}"
+echo "${RUBY_ARCHIVE_SHA256}  ${RUBY_ARCHIVE}" | sha256sum --check
+rm -rf "${TOOLCHAIN_DATA_DIR}/downloads"
+
+register_tool() {
+  local mise_tool="$1"
+  local toolcache_tool="$2"
+  local version="$3"
+  local executable="$4"
+  local canonical_root="${TOOLCHAIN_DATA_DIR}/installs/${mise_tool}/${version}"
+  local mise_root="/mise/installs/${mise_tool}/${version}"
+  local toolcache_version_root="/opt/hostedtoolcache/${toolcache_tool}/${version}"
+  local toolcache_root="${toolcache_version_root}/${TOOLCACHE_ARCH}"
+
+  test -d "${canonical_root}"
+  test ! -L "${canonical_root}"
+  test -f "${canonical_root}/${executable}"
+  test ! -L "${canonical_root}/${executable}"
+
+  mise link "${mise_tool}@${version}" "${canonical_root}"
+  test -L "${mise_root}"
+  test "$(readlink -f "${mise_root}")" = "${canonical_root}"
+
+  mkdir -p "${toolcache_version_root}"
+  ln -s "${canonical_root}" "${toolcache_root}"
+  test -L "${toolcache_root}"
+  test "$(readlink -f "${toolcache_root}")" = "${canonical_root}"
+}
+
+register_tool node node "${NODE_20_VERSION}" bin/node
+register_tool node node "${NODE_24_VERSION}" bin/node
+register_tool go go "${GO_124_VERSION}" bin/go
+register_tool go go "${GO_125_VERSION}" bin/go
+register_tool go go "${GO_126_VERSION}" bin/go
+register_tool ruby Ruby "${RUBY_VERSION}" bin/ruby
+
+test ! -e /mise/bin/mise
+
+for version in "${NODE_20_VERSION}" "${NODE_24_VERSION}"; do
+  canonical_root="${TOOLCHAIN_DATA_DIR}/installs/node/${version}"
+  test "$(readlink -f "$(mise where "node@${version}")")" = "${canonical_root}"
+  test "$(mise exec "node@${version}" -- node --version)" = "v${version}"
+  EXPECTED_NODE_VERSION="${version}" mise exec "node@${version}" -- node -e \
+    'if (process.versions.node !== process.env.EXPECTED_NODE_VERSION) process.exit(1)'
+done
+
+cat >/tmp/mise-go-smoke.go <<'GO'
+package main
+
+import "fmt"
+
+func main() { fmt.Print("mise-go-ok") }
+GO
+
+for version in "${GO_124_VERSION}" "${GO_125_VERSION}" "${GO_126_VERSION}"; do
+  canonical_root="${TOOLCHAIN_DATA_DIR}/installs/go/${version}"
+  test "$(readlink -f "$(mise where "go@${version}")")" = "${canonical_root}"
+  test "$(mise exec "go@${version}" -- go env GOVERSION)" = "go${version}"
+  test "$(mise exec "go@${version}" -- go run /tmp/mise-go-smoke.go)" = mise-go-ok
+done
+
+export RUBY_ROOT="${TOOLCHAIN_DATA_DIR}/installs/ruby/${RUBY_VERSION}"
+test "$(readlink -f "$(mise where "ruby@${RUBY_VERSION}")")" = "${RUBY_ROOT}"
+EXPECTED_RUBY_VERSION="${RUBY_VERSION}" EXPECTED_RUBY_ROOT="${RUBY_ROOT}" \
+  mise exec "ruby@${RUBY_VERSION}" -- ruby -ropenssl -rrbconfig -e \
+  'abort unless RUBY_VERSION == ENV.fetch("EXPECTED_RUBY_VERSION"); abort unless File.realpath(RbConfig::CONFIG.fetch("prefix")) == ENV.fetch("EXPECTED_RUBY_ROOT")'
+mise exec "ruby@${RUBY_VERSION}" -- gem --version
+mise exec "ruby@${RUBY_VERSION}" -- bundle --version
+
+mkdir /tmp/mise-ruby-native-extension
+cat >/tmp/mise-ruby-native-extension/extconf.rb <<'RUBY'
+require "mkmf"
+create_makefile("mise_image_smoke")
+RUBY
+cat >/tmp/mise-ruby-native-extension/mise_image_smoke.c <<'C'
+#include "ruby.h"
+
+static VALUE ok(VALUE self) { return Qtrue; }
+
+void Init_mise_image_smoke(void) {
+  VALUE module = rb_define_module("MiseImageSmoke");
+  rb_define_singleton_method(module, "ok?", ok, 0);
+}
+C
+pushd /tmp/mise-ruby-native-extension
+mise exec "ruby@${RUBY_VERSION}" -- ruby extconf.rb
+make
+mise exec "ruby@${RUBY_VERSION}" -- ruby -I. -rmise_image_smoke -e \
+  'abort unless MiseImageSmoke.ok?'
+popd
+
+jq -n \
+  --arg architecture "${DEBIAN_ARCH}" \
+  --arg toolcache_architecture "${TOOLCACHE_ARCH}" \
+  --arg mise_version "${MISE_VERSION#v}" \
+  --arg mise_sha256 "$(sha256sum /usr/local/bin/mise | awk '{print $1}')" \
+  --arg root "${TOOLCHAIN_DATA_DIR}" \
+  --arg node20 "${NODE_20_VERSION}" \
+  --arg node24 "${NODE_24_VERSION}" \
+  --arg go124 "${GO_124_VERSION}" \
+  --arg go125 "${GO_125_VERSION}" \
+  --arg go126 "${GO_126_VERSION}" \
+  --arg ruby "${RUBY_VERSION}" \
+  --arg ruby_source_release "${RUBY_SOURCE_RELEASE}" \
+  'def tool($name; $version; $executable): {
+    tool: $name,
+    version: $version,
+    canonical_root: ($root + "/installs/" + $name + "/" + $version),
+    executable: ($root + "/installs/" + $name + "/" + $version + "/" + $executable)
+  } | .executable_sha256 = (input);
+  {
+    schema_version: 1,
+    architecture: $architecture,
+    toolcache_architecture: $toolcache_architecture,
+    canonical_data_dir: $root,
+    mise: {
+      version: $mise_version,
+      executable: "/usr/local/bin/mise",
+      executable_sha256: $mise_sha256
+    },
+    toolchains: [
+      tool("node"; $node20; "bin/node"),
+      tool("node"; $node24; "bin/node"),
+      tool("go"; $go124; "bin/go"),
+      tool("go"; $go125; "bin/go"),
+      tool("go"; $go126; "bin/go"),
+      (tool("ruby"; $ruby; "bin/ruby") + {source_release: $ruby_source_release})
+    ]
+  }' \
+  < <(
+    sha256sum \
+      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_20_VERSION}/bin/node" \
+      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}/bin/node" \
+      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_124_VERSION}/bin/go" \
+      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_125_VERSION}/bin/go" \
+      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_126_VERSION}/bin/go" \
+      "${TOOLCHAIN_DATA_DIR}/installs/ruby/${RUBY_VERSION}/bin/ruby" |
+      awk '{print "\"" $1 "\""}'
+  ) >"${TOOLCHAIN_DATA_DIR}/manifest.json"
+
+test "$(jq -r '.mise.version' "${TOOLCHAIN_DATA_DIR}/manifest.json")" = "$(mise --version | awk '{print $1}')"
+while IFS=$'\t' read -r tool version canonical_root executable executable_sha256; do
+  test -d "${canonical_root}"
+  test ! -L "${canonical_root}"
+  test -f "${executable}"
+  test ! -L "${executable}"
+  test "$(sha256sum "${executable}" | awk '{print $1}')" = "${executable_sha256}"
+  case "${tool}" in
+    node) reported_version="$("${executable}" --version)"; reported_version="${reported_version#v}" ;;
+    go) reported_version="$("${executable}" env GOVERSION)"; reported_version="${reported_version#go}" ;;
+    ruby) reported_version="$("${executable}" -e 'print RUBY_VERSION')" ;;
+  esac
+  test "${reported_version}" = "${version}"
+done < <(jq -r '.toolchains[] | [.tool, .version, .canonical_root, .executable, .executable_sha256] | @tsv' "${TOOLCHAIN_DATA_DIR}/manifest.json")
+
+mark_complete() {
+  local toolcache_tool="$1"
+  local version="$2"
+  local marker="/opt/hostedtoolcache/${toolcache_tool}/${version}/${TOOLCACHE_ARCH}.complete"
+  test ! -e "${marker}"
+  : >"${marker}"
+  test -f "${marker}"
+  test ! -s "${marker}"
+}
+
+mark_complete node "${NODE_20_VERSION}"
+mark_complete node "${NODE_24_VERSION}"
+mark_complete go "${GO_124_VERSION}"
+mark_complete go "${GO_125_VERSION}"
+mark_complete go "${GO_126_VERSION}"
+mark_complete Ruby "${RUBY_VERSION}"
+
+rm -rf /mise/cache /tmp/mise-cache /tmp/mise-config \
+  /tmp/mise-go-smoke.go /tmp/mise-ruby-native-extension \
+  /tmp/mise-ruby-project /tmp/mise-ruby-release.json \
+  /tmp/mise-ruby-candidate-release.json
 
 # install aws-cli
 curl https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip -o /tmp/awscliv2.zip
@@ -109,4 +418,3 @@ FROM base
 
 WORKDIR /root
 USER root
-

--- a/ubuntu-jammy-hosted/Dockerfile
+++ b/ubuntu-jammy-hosted/Dockerfile
@@ -20,7 +20,7 @@ ENV MISE_DATA_DIR="/mise"
 ENV MISE_CONFIG_DIR="/mise"
 ENV MISE_CACHE_DIR="/mise/cache"
 ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
-ENV PATH="/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}/bin:/mise/shims:$PATH"
+ENV PATH="/mise/shims:/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}/bin:$PATH"
 
 ARG TARGETARCH
 

--- a/ubuntu-noble-hosted-toolchains/README.md
+++ b/ubuntu-noble-hosted-toolchains/README.md
@@ -1,0 +1,6 @@
+# ubuntu-noble-hosted-toolchains
+
+This variant has no separate Dockerfile. It is built from the `toolchains`
+target in [`../ubuntu-noble-hosted/Dockerfile`](../ubuntu-noble-hosted/Dockerfile),
+selected by
+[`build-docker-base-image.sh`](../.buildkite/steps/build-docker-base-image.sh).

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -4,6 +4,11 @@ FROM public.ecr.aws/ubuntu/ubuntu:24.04 AS base
 
 ARG BAZELISK_VERSION=v1.29.0
 ARG BK_CLI_VERSION=3.40.0
+ARG MISE_VERSION=v2026.8.3
+ARG MISE_SHA256_AMD64=66585ac496c10bf6fbf13272e3e550c1813aed0e1cb780b9bb73c1751de49289
+ARG MISE_SHA256_ARM64=a5bdab52367ecca6c253b60f74d85f8cefe51f613e3b7fcec7b7a5f1dc1bbb41
+ARG NODE_20_VERSION=20.20.2
+ARG NODE_24_VERSION=24.18.0
 
 ENV LC_CTYPE="C.UTF-8"
 
@@ -72,8 +77,312 @@ curl -fLo /tmp/bk.deb https://github.com/buildkite/cli/releases/download/v${BK_C
 dpkg -i /tmp/bk.deb
 rm -f /tmp/bk.deb
 
-# install mise
-curl -fsL https://mise.run | bash
+# install a pinned mise binary and preload common Hosted toolchains
+export MISE_ARCH=x64
+export MISE_SHA256=${MISE_SHA256_AMD64}
+export TOOLCACHE_ARCH=x64
+if [ "${DEBIAN_ARCH}" = "arm64" ]; then
+  export MISE_ARCH=arm64
+  export MISE_SHA256=${MISE_SHA256_ARM64}
+  export TOOLCACHE_ARCH=arm64
+fi
+
+curl -fLo /usr/local/bin/mise https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-${MISE_ARCH}
+echo "${MISE_SHA256}  /usr/local/bin/mise" | sha256sum --check
+chmod 0755 /usr/local/bin/mise
+test "$(mise --version | awk '{print $1}')" = "${MISE_VERSION#v}"
+
+export TOOLCHAIN_DATA_DIR=/opt/buildkite/mise-toolchains
+
+canonical_mise() {
+  MISE_DATA_DIR="${TOOLCHAIN_DATA_DIR}" \
+    MISE_CONFIG_DIR=/tmp/mise-config \
+    MISE_CACHE_DIR=/tmp/mise-cache \
+    MISE_RUBY_COMPILE=false \
+    mise "$@"
+}
+
+export GO_124_VERSION="$(canonical_mise latest go@1.24)"
+export GO_125_VERSION="$(canonical_mise latest go@1.25)"
+export GO_126_VERSION="$(canonical_mise latest go@1.26)"
+
+[[ "${GO_124_VERSION}" =~ ^1\.24\.[0-9]+$ ]]
+[[ "${GO_125_VERSION}" =~ ^1\.25\.[0-9]+$ ]]
+[[ "${GO_126_VERSION}" =~ ^1\.26\.[0-9]+$ ]]
+
+# Resolve the newest stable Ruby with precompiled assets for both Linux
+# architectures. An ephemeral lockfile selects its exact jdx/ruby build
+# revision without relying on the anonymous GitHub API quota.
+export RUBY_VERSION=
+export RUBY_SOURCE_RELEASE=
+for candidate in $(curl --retry 3 --retry-all-errors -fsSL https://mise-versions.jdx.dev/ruby | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr); do
+  candidate_release=
+  revision=1
+  while true; do
+    if [ "${revision}" -gt 1000 ]; then
+      echo "Refusing to resolve more than 1000 jdx/ruby revisions for ${candidate}" >&2
+      exit 1
+    fi
+    release="${candidate}-${revision}"
+    status="$(curl --retry 3 --retry-all-errors -sSL \
+      -o /tmp/mise-ruby-candidate-release.json -w '%{http_code}' \
+      "https://mise-versions.jdx.dev/api/github/repos/jdx/ruby/releases/${release}")"
+    case "${status}" in
+      200)
+        if jq -e --arg version "${candidate}" --arg release "${release}" '
+          .tag_name == $release and
+          any(.assets[]; .name == ("ruby-" + $version + ".x86_64_linux.tar.gz") and (.digest | test("^sha256:[0-9a-f]{64}$"))) and
+          any(.assets[]; .name == ("ruby-" + $version + ".arm64_linux.tar.gz") and (.digest | test("^sha256:[0-9a-f]{64}$")))
+        ' /tmp/mise-ruby-candidate-release.json >/dev/null; then
+          mv /tmp/mise-ruby-candidate-release.json /tmp/mise-ruby-release.json
+          candidate_release="${release}"
+        fi
+        ;;
+      404) break ;;
+      *) echo "Failed to resolve ${release}: HTTP ${status}" >&2; exit 1 ;;
+    esac
+    revision=$((revision + 1))
+  done
+  if [ -n "${candidate_release}" ]; then
+    RUBY_VERSION="${candidate}"
+    RUBY_SOURCE_RELEASE="${candidate_release}"
+    break
+  fi
+done
+test -n "${RUBY_VERSION}"
+test -n "${RUBY_SOURCE_RELEASE}"
+
+export RUBY_X64_ASSET="ruby-${RUBY_VERSION}.x86_64_linux.tar.gz"
+export RUBY_ARM64_ASSET="ruby-${RUBY_VERSION}.arm64_linux.tar.gz"
+export RUBY_X64_URL="$(jq -r --arg asset "${RUBY_X64_ASSET}" '.assets[] | select(.name == $asset) | .browser_download_url' /tmp/mise-ruby-release.json)"
+export RUBY_ARM64_URL="$(jq -r --arg asset "${RUBY_ARM64_ASSET}" '.assets[] | select(.name == $asset) | .browser_download_url' /tmp/mise-ruby-release.json)"
+export RUBY_X64_SHA256="$(jq -r --arg asset "${RUBY_X64_ASSET}" '.assets[] | select(.name == $asset) | .digest' /tmp/mise-ruby-release.json)"
+export RUBY_ARM64_SHA256="$(jq -r --arg asset "${RUBY_ARM64_ASSET}" '.assets[] | select(.name == $asset) | .digest' /tmp/mise-ruby-release.json)"
+
+mkdir /tmp/mise-ruby-project
+cat >/tmp/mise-ruby-project/mise.toml <<TOML
+[tools]
+ruby = "${RUBY_VERSION}"
+
+[settings]
+lockfile = true
+ruby.compile = false
+TOML
+cat >/tmp/mise-ruby-project/mise.lock <<TOML
+[[tools.ruby]]
+version = "${RUBY_VERSION}"
+backend = "core:ruby"
+
+[tools.ruby.options]
+compile = "false"
+precompiled_url = "jdx/ruby"
+ruby_build_repo = "https://github.com/rbenv/ruby-build.git"
+ruby_install = "false"
+
+[tools.ruby."platforms.linux-x64"]
+url = "${RUBY_X64_URL}"
+checksum = "${RUBY_X64_SHA256}"
+
+[tools.ruby."platforms.linux-arm64"]
+url = "${RUBY_ARM64_URL}"
+checksum = "${RUBY_ARM64_SHA256}"
+TOML
+
+canonical_mise install "node@${NODE_20_VERSION}"
+canonical_mise install "node@${NODE_24_VERSION}"
+canonical_mise install "go@${GO_124_VERSION}"
+canonical_mise install "go@${GO_125_VERSION}"
+canonical_mise install "go@${GO_126_VERSION}"
+canonical_mise trust /tmp/mise-ruby-project/mise.toml
+(
+  cd /tmp/mise-ruby-project
+  export MISE_ALWAYS_KEEP_DOWNLOAD=1
+  canonical_mise install --locked
+)
+
+export RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_X64_ASSET}"
+export RUBY_ARCHIVE_SHA256="${RUBY_X64_SHA256#sha256:}"
+if [ "${DEBIAN_ARCH}" = "arm64" ]; then
+  RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_ARM64_ASSET}"
+  RUBY_ARCHIVE_SHA256="${RUBY_ARM64_SHA256#sha256:}"
+fi
+test -f "${RUBY_ARCHIVE}"
+test ! -L "${RUBY_ARCHIVE}"
+echo "${RUBY_ARCHIVE_SHA256}  ${RUBY_ARCHIVE}" | sha256sum --check
+rm -rf "${TOOLCHAIN_DATA_DIR}/downloads"
+
+register_tool() {
+  local mise_tool="$1"
+  local toolcache_tool="$2"
+  local version="$3"
+  local executable="$4"
+  local canonical_root="${TOOLCHAIN_DATA_DIR}/installs/${mise_tool}/${version}"
+  local mise_root="/mise/installs/${mise_tool}/${version}"
+  local toolcache_version_root="/opt/hostedtoolcache/${toolcache_tool}/${version}"
+  local toolcache_root="${toolcache_version_root}/${TOOLCACHE_ARCH}"
+
+  test -d "${canonical_root}"
+  test ! -L "${canonical_root}"
+  test -f "${canonical_root}/${executable}"
+  test ! -L "${canonical_root}/${executable}"
+
+  mise link "${mise_tool}@${version}" "${canonical_root}"
+  test -L "${mise_root}"
+  test "$(readlink -f "${mise_root}")" = "${canonical_root}"
+
+  mkdir -p "${toolcache_version_root}"
+  ln -s "${canonical_root}" "${toolcache_root}"
+  test -L "${toolcache_root}"
+  test "$(readlink -f "${toolcache_root}")" = "${canonical_root}"
+}
+
+register_tool node node "${NODE_20_VERSION}" bin/node
+register_tool node node "${NODE_24_VERSION}" bin/node
+register_tool go go "${GO_124_VERSION}" bin/go
+register_tool go go "${GO_125_VERSION}" bin/go
+register_tool go go "${GO_126_VERSION}" bin/go
+register_tool ruby Ruby "${RUBY_VERSION}" bin/ruby
+
+test ! -e /mise/bin/mise
+
+for version in "${NODE_20_VERSION}" "${NODE_24_VERSION}"; do
+  canonical_root="${TOOLCHAIN_DATA_DIR}/installs/node/${version}"
+  test "$(readlink -f "$(mise where "node@${version}")")" = "${canonical_root}"
+  test "$(mise exec "node@${version}" -- node --version)" = "v${version}"
+  EXPECTED_NODE_VERSION="${version}" mise exec "node@${version}" -- node -e \
+    'if (process.versions.node !== process.env.EXPECTED_NODE_VERSION) process.exit(1)'
+done
+
+cat >/tmp/mise-go-smoke.go <<'GO'
+package main
+
+import "fmt"
+
+func main() { fmt.Print("mise-go-ok") }
+GO
+
+for version in "${GO_124_VERSION}" "${GO_125_VERSION}" "${GO_126_VERSION}"; do
+  canonical_root="${TOOLCHAIN_DATA_DIR}/installs/go/${version}"
+  test "$(readlink -f "$(mise where "go@${version}")")" = "${canonical_root}"
+  test "$(mise exec "go@${version}" -- go env GOVERSION)" = "go${version}"
+  test "$(mise exec "go@${version}" -- go run /tmp/mise-go-smoke.go)" = mise-go-ok
+done
+
+export RUBY_ROOT="${TOOLCHAIN_DATA_DIR}/installs/ruby/${RUBY_VERSION}"
+test "$(readlink -f "$(mise where "ruby@${RUBY_VERSION}")")" = "${RUBY_ROOT}"
+EXPECTED_RUBY_VERSION="${RUBY_VERSION}" EXPECTED_RUBY_ROOT="${RUBY_ROOT}" \
+  mise exec "ruby@${RUBY_VERSION}" -- ruby -ropenssl -rrbconfig -e \
+  'abort unless RUBY_VERSION == ENV.fetch("EXPECTED_RUBY_VERSION"); abort unless File.realpath(RbConfig::CONFIG.fetch("prefix")) == ENV.fetch("EXPECTED_RUBY_ROOT")'
+mise exec "ruby@${RUBY_VERSION}" -- gem --version
+mise exec "ruby@${RUBY_VERSION}" -- bundle --version
+
+mkdir /tmp/mise-ruby-native-extension
+cat >/tmp/mise-ruby-native-extension/extconf.rb <<'RUBY'
+require "mkmf"
+create_makefile("mise_image_smoke")
+RUBY
+cat >/tmp/mise-ruby-native-extension/mise_image_smoke.c <<'C'
+#include "ruby.h"
+
+static VALUE ok(VALUE self) { return Qtrue; }
+
+void Init_mise_image_smoke(void) {
+  VALUE module = rb_define_module("MiseImageSmoke");
+  rb_define_singleton_method(module, "ok?", ok, 0);
+}
+C
+pushd /tmp/mise-ruby-native-extension
+mise exec "ruby@${RUBY_VERSION}" -- ruby extconf.rb
+make
+mise exec "ruby@${RUBY_VERSION}" -- ruby -I. -rmise_image_smoke -e \
+  'abort unless MiseImageSmoke.ok?'
+popd
+
+jq -n \
+  --arg architecture "${DEBIAN_ARCH}" \
+  --arg toolcache_architecture "${TOOLCACHE_ARCH}" \
+  --arg mise_version "${MISE_VERSION#v}" \
+  --arg mise_sha256 "$(sha256sum /usr/local/bin/mise | awk '{print $1}')" \
+  --arg root "${TOOLCHAIN_DATA_DIR}" \
+  --arg node20 "${NODE_20_VERSION}" \
+  --arg node24 "${NODE_24_VERSION}" \
+  --arg go124 "${GO_124_VERSION}" \
+  --arg go125 "${GO_125_VERSION}" \
+  --arg go126 "${GO_126_VERSION}" \
+  --arg ruby "${RUBY_VERSION}" \
+  --arg ruby_source_release "${RUBY_SOURCE_RELEASE}" \
+  'def tool($name; $version; $executable): {
+    tool: $name,
+    version: $version,
+    canonical_root: ($root + "/installs/" + $name + "/" + $version),
+    executable: ($root + "/installs/" + $name + "/" + $version + "/" + $executable)
+  } | .executable_sha256 = (input);
+  {
+    schema_version: 1,
+    architecture: $architecture,
+    toolcache_architecture: $toolcache_architecture,
+    canonical_data_dir: $root,
+    mise: {
+      version: $mise_version,
+      executable: "/usr/local/bin/mise",
+      executable_sha256: $mise_sha256
+    },
+    toolchains: [
+      tool("node"; $node20; "bin/node"),
+      tool("node"; $node24; "bin/node"),
+      tool("go"; $go124; "bin/go"),
+      tool("go"; $go125; "bin/go"),
+      tool("go"; $go126; "bin/go"),
+      (tool("ruby"; $ruby; "bin/ruby") + {source_release: $ruby_source_release})
+    ]
+  }' \
+  < <(
+    sha256sum \
+      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_20_VERSION}/bin/node" \
+      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}/bin/node" \
+      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_124_VERSION}/bin/go" \
+      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_125_VERSION}/bin/go" \
+      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_126_VERSION}/bin/go" \
+      "${TOOLCHAIN_DATA_DIR}/installs/ruby/${RUBY_VERSION}/bin/ruby" |
+      awk '{print "\"" $1 "\""}'
+  ) >"${TOOLCHAIN_DATA_DIR}/manifest.json"
+
+test "$(jq -r '.mise.version' "${TOOLCHAIN_DATA_DIR}/manifest.json")" = "$(mise --version | awk '{print $1}')"
+while IFS=$'\t' read -r tool version canonical_root executable executable_sha256; do
+  test -d "${canonical_root}"
+  test ! -L "${canonical_root}"
+  test -f "${executable}"
+  test ! -L "${executable}"
+  test "$(sha256sum "${executable}" | awk '{print $1}')" = "${executable_sha256}"
+  case "${tool}" in
+    node) reported_version="$("${executable}" --version)"; reported_version="${reported_version#v}" ;;
+    go) reported_version="$("${executable}" env GOVERSION)"; reported_version="${reported_version#go}" ;;
+    ruby) reported_version="$("${executable}" -e 'print RUBY_VERSION')" ;;
+  esac
+  test "${reported_version}" = "${version}"
+done < <(jq -r '.toolchains[] | [.tool, .version, .canonical_root, .executable, .executable_sha256] | @tsv' "${TOOLCHAIN_DATA_DIR}/manifest.json")
+
+mark_complete() {
+  local toolcache_tool="$1"
+  local version="$2"
+  local marker="/opt/hostedtoolcache/${toolcache_tool}/${version}/${TOOLCACHE_ARCH}.complete"
+  test ! -e "${marker}"
+  : >"${marker}"
+  test -f "${marker}"
+  test ! -s "${marker}"
+}
+
+mark_complete node "${NODE_20_VERSION}"
+mark_complete node "${NODE_24_VERSION}"
+mark_complete go "${GO_124_VERSION}"
+mark_complete go "${GO_125_VERSION}"
+mark_complete go "${GO_126_VERSION}"
+mark_complete Ruby "${RUBY_VERSION}"
+
+rm -rf /mise/cache /tmp/mise-cache /tmp/mise-config \
+  /tmp/mise-go-smoke.go /tmp/mise-ruby-native-extension \
+  /tmp/mise-ruby-project /tmp/mise-ruby-release.json \
+  /tmp/mise-ruby-candidate-release.json
 
 # install aws-cli
 curl https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip -o /tmp/awscliv2.zip

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -27,6 +27,7 @@ ARG TARGETARCH
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-${TARGETARCH},sharing=locked \
 --mount=type=cache,target=/var/lib/apt,id=apt-lib-${TARGETARCH},sharing=locked \
 --mount=type=cache,target=/var/cache/debconf,id=debconf-${TARGETARCH},sharing=locked \
+--mount=type=bind,source=common/install-mise-default-node.sh,target=/install-mise-default-node.sh \
 <<BASH
 #!/usr/bin/env bash
 
@@ -80,30 +81,7 @@ curl -fLo /tmp/bk.deb https://github.com/buildkite/cli/releases/download/v${BK_C
 dpkg -i /tmp/bk.deb
 rm -f /tmp/bk.deb
 
-# install pinned mise binary
-export MISE_ARCH=x64
-export MISE_SHA256=${MISE_SHA256_AMD64}
-if [ "${DEBIAN_ARCH}" = "arm64" ]; then
-  MISE_ARCH=arm64
-  MISE_SHA256=${MISE_SHA256_ARM64}
-fi
-curl -fLo /usr/local/bin/mise https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-${MISE_ARCH}
-echo "${MISE_SHA256}  /usr/local/bin/mise" | sha256sum --check
-chmod 0755 /usr/local/bin/mise
-test "$(mise --version | awk '{print $1}')" = "${MISE_VERSION#v}"
-
-# Install the image's default Node at its permanent mise-owned root. The
-# toolchains target registers this same directory with mise and setup-node.
-export NODE_24_ROOT="/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}"
-MISE_DATA_DIR=/opt/buildkite/mise-toolchains \
-  MISE_CONFIG_DIR=/tmp/mise-config \
-  MISE_CACHE_DIR=/tmp/mise-cache \
-  mise install "node@${NODE_24_VERSION}"
-test -d "${NODE_24_ROOT}"
-test ! -L "${NODE_24_ROOT}"
-test "$(readlink -f "$(command -v node)")" = "${NODE_24_ROOT}/bin/node"
-test "$(node --version)" = "v${NODE_24_VERSION}"
-rm -rf /tmp/mise-cache /tmp/mise-config
+bash /install-mise-default-node.sh
 
 # install aws-cli
 curl https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip -o /tmp/awscliv2.zip

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 ARG MISE_VERSION=v2026.8.3
-ARG NODE_20_VERSION=20.20.2
+ARG NODE_22_VERSION=22.23.2
 ARG NODE_24_VERSION=24.18.0
 
 FROM public.ecr.aws/ubuntu/ubuntu:24.04 AS base
@@ -9,6 +9,7 @@ FROM public.ecr.aws/ubuntu/ubuntu:24.04 AS base
 ARG BAZELISK_VERSION=v1.29.0
 ARG BK_CLI_VERSION=3.40.0
 ARG MISE_VERSION
+ARG NODE_24_VERSION
 ARG MISE_SHA256_AMD64=66585ac496c10bf6fbf13272e3e550c1813aed0e1cb780b9bb73c1751de49289
 ARG MISE_SHA256_ARM64=a5bdab52367ecca6c253b60f74d85f8cefe51f613e3b7fcec7b7a5f1dc1bbb41
 
@@ -19,7 +20,7 @@ ENV MISE_DATA_DIR="/mise"
 ENV MISE_CONFIG_DIR="/mise"
 ENV MISE_CACHE_DIR="/mise/cache"
 ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
-ENV PATH="/mise/shims:$PATH"
+ENV PATH="/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}/bin:/mise/shims:$PATH"
 
 ARG TARGETARCH
 
@@ -91,6 +92,19 @@ echo "${MISE_SHA256}  /usr/local/bin/mise" | sha256sum --check
 chmod 0755 /usr/local/bin/mise
 test "$(mise --version | awk '{print $1}')" = "${MISE_VERSION#v}"
 
+# Install the image's default Node at its permanent mise-owned root. The
+# toolchains target registers this same directory with mise and setup-node.
+export NODE_24_ROOT="/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}"
+MISE_DATA_DIR=/opt/buildkite/mise-toolchains \
+  MISE_CONFIG_DIR=/tmp/mise-config \
+  MISE_CACHE_DIR=/tmp/mise-cache \
+  mise install "node@${NODE_24_VERSION}"
+test -d "${NODE_24_ROOT}"
+test ! -L "${NODE_24_ROOT}"
+test "$(readlink -f "$(command -v node)")" = "${NODE_24_ROOT}/bin/node"
+test "$(node --version)" = "v${NODE_24_VERSION}"
+rm -rf /tmp/mise-cache /tmp/mise-config
+
 # install aws-cli
 curl https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip -o /tmp/awscliv2.zip
 unzip -q /tmp/awscliv2.zip -d /opt
@@ -107,14 +121,7 @@ apt-get update
 apt-get install -y google-cloud-cli=502.0.0-0
 gcloud --version
 
-# install nodejs
-git clone https://github.com/tj/n /usr/src/n
-pushd /usr/src/n
-make install
-popd
-n lts
-rm -rf /usr/src/n /tmp/*
-node --version
+rm -rf /tmp/*
 
 ln -s /usr/bin/tini /usr/sbin/tini
 
@@ -127,7 +134,7 @@ BASH
 FROM base AS toolchains
 
 ARG MISE_VERSION
-ARG NODE_20_VERSION
+ARG NODE_22_VERSION
 ARG NODE_24_VERSION
 
 RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -20,7 +20,7 @@ ENV MISE_DATA_DIR="/mise"
 ENV MISE_CONFIG_DIR="/mise"
 ENV MISE_CACHE_DIR="/mise/cache"
 ENV MISE_INSTALL_PATH="/usr/local/bin/mise"
-ENV PATH="/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}/bin:/mise/shims:$PATH"
+ENV PATH="/mise/shims:/opt/buildkite/mise-toolchains/installs/node/${NODE_24_VERSION}/bin:$PATH"
 
 ARG TARGETARCH
 

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -1,14 +1,16 @@
 # syntax=docker/dockerfile:1.4
 
+ARG MISE_VERSION=v2026.8.3
+ARG NODE_20_VERSION=20.20.2
+ARG NODE_24_VERSION=24.18.0
+
 FROM public.ecr.aws/ubuntu/ubuntu:24.04 AS base
 
 ARG BAZELISK_VERSION=v1.29.0
 ARG BK_CLI_VERSION=3.40.0
-ARG MISE_VERSION=v2026.8.3
+ARG MISE_VERSION
 ARG MISE_SHA256_AMD64=66585ac496c10bf6fbf13272e3e550c1813aed0e1cb780b9bb73c1751de49289
 ARG MISE_SHA256_ARM64=a5bdab52367ecca6c253b60f74d85f8cefe51f613e3b7fcec7b7a5f1dc1bbb41
-ARG NODE_20_VERSION=20.20.2
-ARG NODE_24_VERSION=24.18.0
 
 ENV LC_CTYPE="C.UTF-8"
 
@@ -77,312 +79,17 @@ curl -fLo /tmp/bk.deb https://github.com/buildkite/cli/releases/download/v${BK_C
 dpkg -i /tmp/bk.deb
 rm -f /tmp/bk.deb
 
-# install a pinned mise binary and preload common Hosted toolchains
+# install pinned mise binary
 export MISE_ARCH=x64
 export MISE_SHA256=${MISE_SHA256_AMD64}
-export TOOLCACHE_ARCH=x64
 if [ "${DEBIAN_ARCH}" = "arm64" ]; then
-  export MISE_ARCH=arm64
-  export MISE_SHA256=${MISE_SHA256_ARM64}
-  export TOOLCACHE_ARCH=arm64
+  MISE_ARCH=arm64
+  MISE_SHA256=${MISE_SHA256_ARM64}
 fi
-
 curl -fLo /usr/local/bin/mise https://github.com/jdx/mise/releases/download/${MISE_VERSION}/mise-${MISE_VERSION}-linux-${MISE_ARCH}
 echo "${MISE_SHA256}  /usr/local/bin/mise" | sha256sum --check
 chmod 0755 /usr/local/bin/mise
 test "$(mise --version | awk '{print $1}')" = "${MISE_VERSION#v}"
-
-export TOOLCHAIN_DATA_DIR=/opt/buildkite/mise-toolchains
-
-canonical_mise() {
-  MISE_DATA_DIR="${TOOLCHAIN_DATA_DIR}" \
-    MISE_CONFIG_DIR=/tmp/mise-config \
-    MISE_CACHE_DIR=/tmp/mise-cache \
-    MISE_RUBY_COMPILE=false \
-    mise "$@"
-}
-
-export GO_124_VERSION="$(canonical_mise latest go@1.24)"
-export GO_125_VERSION="$(canonical_mise latest go@1.25)"
-export GO_126_VERSION="$(canonical_mise latest go@1.26)"
-
-[[ "${GO_124_VERSION}" =~ ^1\.24\.[0-9]+$ ]]
-[[ "${GO_125_VERSION}" =~ ^1\.25\.[0-9]+$ ]]
-[[ "${GO_126_VERSION}" =~ ^1\.26\.[0-9]+$ ]]
-
-# Resolve the newest stable Ruby with precompiled assets for both Linux
-# architectures. An ephemeral lockfile selects its exact jdx/ruby build
-# revision without relying on the anonymous GitHub API quota.
-export RUBY_VERSION=
-export RUBY_SOURCE_RELEASE=
-for candidate in $(curl --retry 3 --retry-all-errors -fsSL https://mise-versions.jdx.dev/ruby | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr); do
-  candidate_release=
-  revision=1
-  while true; do
-    if [ "${revision}" -gt 1000 ]; then
-      echo "Refusing to resolve more than 1000 jdx/ruby revisions for ${candidate}" >&2
-      exit 1
-    fi
-    release="${candidate}-${revision}"
-    status="$(curl --retry 3 --retry-all-errors -sSL \
-      -o /tmp/mise-ruby-candidate-release.json -w '%{http_code}' \
-      "https://mise-versions.jdx.dev/api/github/repos/jdx/ruby/releases/${release}")"
-    case "${status}" in
-      200)
-        if jq -e --arg version "${candidate}" --arg release "${release}" '
-          .tag_name == $release and
-          any(.assets[]; .name == ("ruby-" + $version + ".x86_64_linux.tar.gz") and (.digest | test("^sha256:[0-9a-f]{64}$"))) and
-          any(.assets[]; .name == ("ruby-" + $version + ".arm64_linux.tar.gz") and (.digest | test("^sha256:[0-9a-f]{64}$")))
-        ' /tmp/mise-ruby-candidate-release.json >/dev/null; then
-          mv /tmp/mise-ruby-candidate-release.json /tmp/mise-ruby-release.json
-          candidate_release="${release}"
-        fi
-        ;;
-      404) break ;;
-      *) echo "Failed to resolve ${release}: HTTP ${status}" >&2; exit 1 ;;
-    esac
-    revision=$((revision + 1))
-  done
-  if [ -n "${candidate_release}" ]; then
-    RUBY_VERSION="${candidate}"
-    RUBY_SOURCE_RELEASE="${candidate_release}"
-    break
-  fi
-done
-test -n "${RUBY_VERSION}"
-test -n "${RUBY_SOURCE_RELEASE}"
-
-export RUBY_X64_ASSET="ruby-${RUBY_VERSION}.x86_64_linux.tar.gz"
-export RUBY_ARM64_ASSET="ruby-${RUBY_VERSION}.arm64_linux.tar.gz"
-export RUBY_X64_URL="$(jq -r --arg asset "${RUBY_X64_ASSET}" '.assets[] | select(.name == $asset) | .browser_download_url' /tmp/mise-ruby-release.json)"
-export RUBY_ARM64_URL="$(jq -r --arg asset "${RUBY_ARM64_ASSET}" '.assets[] | select(.name == $asset) | .browser_download_url' /tmp/mise-ruby-release.json)"
-export RUBY_X64_SHA256="$(jq -r --arg asset "${RUBY_X64_ASSET}" '.assets[] | select(.name == $asset) | .digest' /tmp/mise-ruby-release.json)"
-export RUBY_ARM64_SHA256="$(jq -r --arg asset "${RUBY_ARM64_ASSET}" '.assets[] | select(.name == $asset) | .digest' /tmp/mise-ruby-release.json)"
-
-mkdir /tmp/mise-ruby-project
-cat >/tmp/mise-ruby-project/mise.toml <<TOML
-[tools]
-ruby = "${RUBY_VERSION}"
-
-[settings]
-lockfile = true
-ruby.compile = false
-TOML
-cat >/tmp/mise-ruby-project/mise.lock <<TOML
-[[tools.ruby]]
-version = "${RUBY_VERSION}"
-backend = "core:ruby"
-
-[tools.ruby.options]
-compile = "false"
-precompiled_url = "jdx/ruby"
-ruby_build_repo = "https://github.com/rbenv/ruby-build.git"
-ruby_install = "false"
-
-[tools.ruby."platforms.linux-x64"]
-url = "${RUBY_X64_URL}"
-checksum = "${RUBY_X64_SHA256}"
-
-[tools.ruby."platforms.linux-arm64"]
-url = "${RUBY_ARM64_URL}"
-checksum = "${RUBY_ARM64_SHA256}"
-TOML
-
-canonical_mise install "node@${NODE_20_VERSION}"
-canonical_mise install "node@${NODE_24_VERSION}"
-canonical_mise install "go@${GO_124_VERSION}"
-canonical_mise install "go@${GO_125_VERSION}"
-canonical_mise install "go@${GO_126_VERSION}"
-canonical_mise trust /tmp/mise-ruby-project/mise.toml
-(
-  cd /tmp/mise-ruby-project
-  export MISE_ALWAYS_KEEP_DOWNLOAD=1
-  canonical_mise install --locked
-)
-
-export RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_X64_ASSET}"
-export RUBY_ARCHIVE_SHA256="${RUBY_X64_SHA256#sha256:}"
-if [ "${DEBIAN_ARCH}" = "arm64" ]; then
-  RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_ARM64_ASSET}"
-  RUBY_ARCHIVE_SHA256="${RUBY_ARM64_SHA256#sha256:}"
-fi
-test -f "${RUBY_ARCHIVE}"
-test ! -L "${RUBY_ARCHIVE}"
-echo "${RUBY_ARCHIVE_SHA256}  ${RUBY_ARCHIVE}" | sha256sum --check
-rm -rf "${TOOLCHAIN_DATA_DIR}/downloads"
-
-register_tool() {
-  local mise_tool="$1"
-  local toolcache_tool="$2"
-  local version="$3"
-  local executable="$4"
-  local canonical_root="${TOOLCHAIN_DATA_DIR}/installs/${mise_tool}/${version}"
-  local mise_root="/mise/installs/${mise_tool}/${version}"
-  local toolcache_version_root="/opt/hostedtoolcache/${toolcache_tool}/${version}"
-  local toolcache_root="${toolcache_version_root}/${TOOLCACHE_ARCH}"
-
-  test -d "${canonical_root}"
-  test ! -L "${canonical_root}"
-  test -f "${canonical_root}/${executable}"
-  test ! -L "${canonical_root}/${executable}"
-
-  mise link "${mise_tool}@${version}" "${canonical_root}"
-  test -L "${mise_root}"
-  test "$(readlink -f "${mise_root}")" = "${canonical_root}"
-
-  mkdir -p "${toolcache_version_root}"
-  ln -s "${canonical_root}" "${toolcache_root}"
-  test -L "${toolcache_root}"
-  test "$(readlink -f "${toolcache_root}")" = "${canonical_root}"
-}
-
-register_tool node node "${NODE_20_VERSION}" bin/node
-register_tool node node "${NODE_24_VERSION}" bin/node
-register_tool go go "${GO_124_VERSION}" bin/go
-register_tool go go "${GO_125_VERSION}" bin/go
-register_tool go go "${GO_126_VERSION}" bin/go
-register_tool ruby Ruby "${RUBY_VERSION}" bin/ruby
-
-test ! -e /mise/bin/mise
-
-for version in "${NODE_20_VERSION}" "${NODE_24_VERSION}"; do
-  canonical_root="${TOOLCHAIN_DATA_DIR}/installs/node/${version}"
-  test "$(readlink -f "$(mise where "node@${version}")")" = "${canonical_root}"
-  test "$(mise exec "node@${version}" -- node --version)" = "v${version}"
-  EXPECTED_NODE_VERSION="${version}" mise exec "node@${version}" -- node -e \
-    'if (process.versions.node !== process.env.EXPECTED_NODE_VERSION) process.exit(1)'
-done
-
-cat >/tmp/mise-go-smoke.go <<'GO'
-package main
-
-import "fmt"
-
-func main() { fmt.Print("mise-go-ok") }
-GO
-
-for version in "${GO_124_VERSION}" "${GO_125_VERSION}" "${GO_126_VERSION}"; do
-  canonical_root="${TOOLCHAIN_DATA_DIR}/installs/go/${version}"
-  test "$(readlink -f "$(mise where "go@${version}")")" = "${canonical_root}"
-  test "$(mise exec "go@${version}" -- go env GOVERSION)" = "go${version}"
-  test "$(mise exec "go@${version}" -- go run /tmp/mise-go-smoke.go)" = mise-go-ok
-done
-
-export RUBY_ROOT="${TOOLCHAIN_DATA_DIR}/installs/ruby/${RUBY_VERSION}"
-test "$(readlink -f "$(mise where "ruby@${RUBY_VERSION}")")" = "${RUBY_ROOT}"
-EXPECTED_RUBY_VERSION="${RUBY_VERSION}" EXPECTED_RUBY_ROOT="${RUBY_ROOT}" \
-  mise exec "ruby@${RUBY_VERSION}" -- ruby -ropenssl -rrbconfig -e \
-  'abort unless RUBY_VERSION == ENV.fetch("EXPECTED_RUBY_VERSION"); abort unless File.realpath(RbConfig::CONFIG.fetch("prefix")) == ENV.fetch("EXPECTED_RUBY_ROOT")'
-mise exec "ruby@${RUBY_VERSION}" -- gem --version
-mise exec "ruby@${RUBY_VERSION}" -- bundle --version
-
-mkdir /tmp/mise-ruby-native-extension
-cat >/tmp/mise-ruby-native-extension/extconf.rb <<'RUBY'
-require "mkmf"
-create_makefile("mise_image_smoke")
-RUBY
-cat >/tmp/mise-ruby-native-extension/mise_image_smoke.c <<'C'
-#include "ruby.h"
-
-static VALUE ok(VALUE self) { return Qtrue; }
-
-void Init_mise_image_smoke(void) {
-  VALUE module = rb_define_module("MiseImageSmoke");
-  rb_define_singleton_method(module, "ok?", ok, 0);
-}
-C
-pushd /tmp/mise-ruby-native-extension
-mise exec "ruby@${RUBY_VERSION}" -- ruby extconf.rb
-make
-mise exec "ruby@${RUBY_VERSION}" -- ruby -I. -rmise_image_smoke -e \
-  'abort unless MiseImageSmoke.ok?'
-popd
-
-jq -n \
-  --arg architecture "${DEBIAN_ARCH}" \
-  --arg toolcache_architecture "${TOOLCACHE_ARCH}" \
-  --arg mise_version "${MISE_VERSION#v}" \
-  --arg mise_sha256 "$(sha256sum /usr/local/bin/mise | awk '{print $1}')" \
-  --arg root "${TOOLCHAIN_DATA_DIR}" \
-  --arg node20 "${NODE_20_VERSION}" \
-  --arg node24 "${NODE_24_VERSION}" \
-  --arg go124 "${GO_124_VERSION}" \
-  --arg go125 "${GO_125_VERSION}" \
-  --arg go126 "${GO_126_VERSION}" \
-  --arg ruby "${RUBY_VERSION}" \
-  --arg ruby_source_release "${RUBY_SOURCE_RELEASE}" \
-  'def tool($name; $version; $executable): {
-    tool: $name,
-    version: $version,
-    canonical_root: ($root + "/installs/" + $name + "/" + $version),
-    executable: ($root + "/installs/" + $name + "/" + $version + "/" + $executable)
-  } | .executable_sha256 = (input);
-  {
-    schema_version: 1,
-    architecture: $architecture,
-    toolcache_architecture: $toolcache_architecture,
-    canonical_data_dir: $root,
-    mise: {
-      version: $mise_version,
-      executable: "/usr/local/bin/mise",
-      executable_sha256: $mise_sha256
-    },
-    toolchains: [
-      tool("node"; $node20; "bin/node"),
-      tool("node"; $node24; "bin/node"),
-      tool("go"; $go124; "bin/go"),
-      tool("go"; $go125; "bin/go"),
-      tool("go"; $go126; "bin/go"),
-      (tool("ruby"; $ruby; "bin/ruby") + {source_release: $ruby_source_release})
-    ]
-  }' \
-  < <(
-    sha256sum \
-      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_20_VERSION}/bin/node" \
-      "${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}/bin/node" \
-      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_124_VERSION}/bin/go" \
-      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_125_VERSION}/bin/go" \
-      "${TOOLCHAIN_DATA_DIR}/installs/go/${GO_126_VERSION}/bin/go" \
-      "${TOOLCHAIN_DATA_DIR}/installs/ruby/${RUBY_VERSION}/bin/ruby" |
-      awk '{print "\"" $1 "\""}'
-  ) >"${TOOLCHAIN_DATA_DIR}/manifest.json"
-
-test "$(jq -r '.mise.version' "${TOOLCHAIN_DATA_DIR}/manifest.json")" = "$(mise --version | awk '{print $1}')"
-while IFS=$'\t' read -r tool version canonical_root executable executable_sha256; do
-  test -d "${canonical_root}"
-  test ! -L "${canonical_root}"
-  test -f "${executable}"
-  test ! -L "${executable}"
-  test "$(sha256sum "${executable}" | awk '{print $1}')" = "${executable_sha256}"
-  case "${tool}" in
-    node) reported_version="$("${executable}" --version)"; reported_version="${reported_version#v}" ;;
-    go) reported_version="$("${executable}" env GOVERSION)"; reported_version="${reported_version#go}" ;;
-    ruby) reported_version="$("${executable}" -e 'print RUBY_VERSION')" ;;
-  esac
-  test "${reported_version}" = "${version}"
-done < <(jq -r '.toolchains[] | [.tool, .version, .canonical_root, .executable, .executable_sha256] | @tsv' "${TOOLCHAIN_DATA_DIR}/manifest.json")
-
-mark_complete() {
-  local toolcache_tool="$1"
-  local version="$2"
-  local marker="/opt/hostedtoolcache/${toolcache_tool}/${version}/${TOOLCACHE_ARCH}.complete"
-  test ! -e "${marker}"
-  : >"${marker}"
-  test -f "${marker}"
-  test ! -s "${marker}"
-}
-
-mark_complete node "${NODE_20_VERSION}"
-mark_complete node "${NODE_24_VERSION}"
-mark_complete go "${GO_124_VERSION}"
-mark_complete go "${GO_125_VERSION}"
-mark_complete go "${GO_126_VERSION}"
-mark_complete Ruby "${RUBY_VERSION}"
-
-rm -rf /mise/cache /tmp/mise-cache /tmp/mise-config \
-  /tmp/mise-go-smoke.go /tmp/mise-ruby-native-extension \
-  /tmp/mise-ruby-project /tmp/mise-ruby-release.json \
-  /tmp/mise-ruby-candidate-release.json
 
 # install aws-cli
 curl https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip -o /tmp/awscliv2.zip
@@ -417,8 +124,21 @@ apt clean all
 rm -rf /var/lib/apt/lists/*
 BASH
 
+FROM base AS toolchains
 
-FROM base
+ARG MISE_VERSION
+ARG NODE_20_VERSION
+ARG NODE_24_VERSION
+
+RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \
+  bash /tmp/install-mise-toolchains.sh
+
+WORKDIR /root
+USER root
+
+# Keep the normal Hosted tag slim; the opt-in variant explicitly builds the
+# toolchains target above.
+FROM base AS hosted
 
 WORKDIR /root
 USER root


### PR DESCRIPTION
## Why

Hosted jobs repeatedly download common user toolchains. Preloading all of them adds substantial image weight, so this PR keeps the existing Hosted tags small and publishes the preload only through explicit `-toolchains` variants.

GitHub-hosted runners execute JavaScript actions with a runner-bundled Node runtime. That runtime is separate from `/opt/hostedtoolcache`: the Node installs here are user toolchains for native mise and setup actions, not action-execution runtimes.

## What

- keeps `ubuntu-jammy-hosted` and `ubuntu-noble-hosted` as the default images
- adds opt-in `ubuntu-jammy-hosted-toolchains` and `ubuntu-noble-hosted-toolchains` variants through the existing native amd64/arm64 manifest pipeline
- replaces the unpinned `n lts` installation with checksum-verified mise Node 24.18.0 at `/opt/buildkite/mise-toolchains/installs/node/24.18.0` and makes that canonical install the default `node` on `PATH`
- preloads exact Node 22.23.2 and 24.18.0 from the current official release/toolset families; the toolchain variants expose both to mise and setup-node without copying SDK bytes
- pins mise 2026.8.3 at `/usr/local/bin/mise` and verifies the architecture-specific release SHA-256; it intentionally does not add `/mise/bin/mise`
- resolves the latest patches in Go 1.24/1.25/1.26 and the latest stable precompiled Ruby during image construction
- requires Ruby precompiled-only behavior, verifies the selected archive digest and GitHub artifact attestation, and requires both Linux architecture assets before selecting a release
- registers `/mise/installs` with supported `mise link` and adds symlink-only `node`, `go`, and `Ruby` views under `/opt/hostedtoolcache`, with completion markers created only after validation
- writes architecture, exact versions, canonical roots, and executable digests to `/opt/buildkite/mise-toolchains/manifest.json`
- documents the opt-in inventory and that future `jdx/mise-action` reuse still requires the workload runtime to preserve `MISE_DATA_DIR=/mise`

This PR changes image definitions and publication targets only. It does not change shared Hosted configuration or `buildkite-gha`, and it does not claim full GitHub Ubuntu image parity.

## amd64 validation

Both default and toolchain targets built locally for Jammy and Noble:

```sh
DOCKER_BUILDKIT=1 docker build --platform linux/amd64 \
  --tag agent-base:node22-slim-<variant>-amd64 \
  --file <variant>/Dockerfile .

DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --target toolchains \
  --tag agent-base:node22-toolchains-<variant>-amd64 \
  --file <variant>/Dockerfile .
```

Both tested toolchain images resolved the same exact inventory:

| Component | Exact result |
| --- | ---: |
| Architecture | amd64 / x64 tool-cache layout |
| mise | 2026.8.3 |
| Node | 22.23.2, 24.18.0 |
| Go | 1.24.13, 1.25.12, 1.26.5 |
| Ruby | 4.0.6 (jdx/ruby release 4.0.6-1) |

Image-construction and independent `docker run` checks passed for both OS variants:

- every manifest version and executable SHA-256 matches the installed executable
- canonical roots and executables are real, non-symlink paths
- `/mise/installs` and `/opt/hostedtoolcache` facades resolve to those canonical roots
- all case-sensitive `x64.complete` markers exist only after validation
- `mise where` and `mise exec` select every linked version
- default `node` resolves to canonical Node 24.18.0; Node 22 and Node 24 smoke checks pass
- Go compilation/execution passes
- Ruby reports exact `RUBY_VERSION` and canonical `RbConfig` prefix, loads OpenSSL, runs RubyGems and Bundler, and compiles/loads a native extension
- `/mise/bin/mise`, the old `n` installation, and build smoke caches are absent

Static checks passed with `bash -n` across all repository shell scripts and `git diff --check`. A final security/simplicity review found no blocker: mise remains pinned and checksum-verified, Node 24 has one canonical copy, Ruby remains fail-closed to precompiled assets, and native publication still waits for both architectures.

## amd64 logical image size

Logical size is Docker's uncompressed image size from `docker image inspect .Size`; it includes layer history and is not registry transfer size. The main baseline, prior draft candidate, and revised candidate used the same local BuildKit method.

| Variant | Main baseline | Prior Node 20/24 draft | Revised default | Revised Node 22/24 toolchains | Revised vs baseline | Revised vs prior draft | Toolchains vs revised default |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Noble | 2,243,894,496 | 3,669,896,160 | 2,043,642,529 | 3,310,313,813 | +1,066,419,317 | -359,582,347 | +1,266,671,284 |
| Jammy | 2,089,412,404 | 3,515,414,075 | 1,889,160,427 | 3,155,831,711 | +1,066,419,307 | -359,582,364 | +1,266,671,284 |

Removing `n lts` makes each revised default about 200.25 MB smaller than the measured main baseline. The revised opt-in image is about 359.58 MB smaller than the prior draft candidate. Its opt-in increment over the matching revised default is 1,266,671,284 bytes (about 1.27 GB / 1.18 GiB).

## Canonical payload size

These are `du -sb` apparent sizes from the final images. Main has no canonical `/opt/buildkite/mise-toolchains/installs` payload, so the useful payload comparison is against the prior draft candidate.

| Variant | Payload | Prior Node 20/24 | Revised Node 22/24 | Delta |
| --- | --- | ---: | ---: | ---: |
| Noble | Node | 356,108,655 | 392,808,931 | +36,700,276 |
| Noble | Go | 692,079,277 | 692,079,277 | 0 |
| Noble | Ruby | 377,587,985 | 377,587,985 | 0 |
| Noble | Total installs | 1,425,776,107 | 1,462,476,383 | +36,700,276 |
| Jammy | Node | 357,839,291 | 394,559,707 | +36,720,416 |
| Jammy | Go | 697,181,165 | 697,181,165 | 0 |
| Jammy | Ruby | 380,718,925 | 380,718,925 | 0 |
| Jammy | Total installs | 1,435,739,699 | 1,472,464,083 | +36,724,384 |

Node 22's extracted payload is slightly larger than Node 20's. The logical image nevertheless shrinks because canonical Node 24 now replaces the older `n`/npm installation and is shared by the default and toolchain targets rather than duplicated.

## Compressed and arm64 evidence

A deterministic baseline-only `docker save | gzip -n | wc -c` measured 652,002,469 bytes for Noble and 595,525,505 bytes for Jammy. Candidate compression was prohibitively slow and stopped, so there is no candidate compressed size or compressed delta; none is estimated here.

Local arm64 images are unavailable because QEMU-emulated builds were prohibitively slow and were stopped. [Buildkite build #714](https://buildkite.com/buildkite/agent-base-images/builds/714) passed in 3 minutes 39 seconds across the repository's native amd64/arm64 branch matrix, including both default and toolchain variants. That is the authoritative arm64, precompiled-asset, and semantic-symmetry gate. Branch CI used `PUSH_IMAGE=false`, so it did not publish candidate images. The PR remains draft and has not been merged.