### PR TITLE
Add Yarn to Hosted toolchain images

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Hosted toolchain variants preloaded with mise:
 
 - two Node.js LTS lines (22 and 24), pinned via the `NODE_22_VERSION` and
   `NODE_24_VERSION` build args in the `-hosted` Dockerfiles
+- Yarn Classic, pinned via the `YARN_VERSION` build arg (currently 1.22.22)
 - the latest patch release from each supported Go 1.24, 1.25, and 1.26 line
 - the latest stable Ruby for which mise has a precompiled binary
 
@@ -62,6 +63,14 @@ Toolchains are stored once under `/opt/buildkite/mise-toolchains/installs` and
 linked into mise's `/mise/installs` and `/opt/hostedtoolcache` (`node`, `go`, and
 `Ruby`) for setup actions. Node 24 is the default on `PATH`; the cache is not the
 runner's JavaScript runtime or full GitHub-hosted Ubuntu parity.
+
+Both preloaded Node versions enable their bundled Corepack Yarn shim and share
+an image-level cache containing the pinned Yarn Classic release, so
+`yarn --version` works without a bootstrap download after either Node version is
+selected. Projects can still select another Yarn release through Corepack's
+standard `packageManager` behavior. A release not already cached needs a
+writable `COREPACK_HOME` (preferably per-user or per-job) and may require network
+access; the image-owned cache is only guaranteed to contain Yarn 1.22.22.
 
 Mise is installed at `/usr/local/bin/mise`, not `/mise/bin/mise`, so `jdx/mise-action`
 can install its requested version. Reuse requires `MISE_DATA_DIR=/mise`; the

--- a/README.md
+++ b/README.md
@@ -64,14 +64,6 @@ linked into mise's `/mise/installs` and `/opt/hostedtoolcache` (`node`, `go`, an
 `Ruby`) for setup actions. Node 24 is the default on `PATH`; the cache is not the
 runner's JavaScript runtime or full GitHub-hosted Ubuntu parity.
 
-Both preloaded Node versions enable their bundled Corepack Yarn shim and share
-an image-level cache containing the pinned Yarn Classic release, so
-`yarn --version` works without a bootstrap download after either Node version is
-selected. Projects can still select another Yarn release through Corepack's
-standard `packageManager` behavior. A release not already cached needs a
-writable `COREPACK_HOME` (preferably per-user or per-job) and may require network
-access; the image-owned cache is only guaranteed to contain Yarn 1.22.22.
-
 Mise is installed at `/usr/local/bin/mise`, not `/mise/bin/mise`, so `jdx/mise-action`
 can install its requested version. Reuse requires `MISE_DATA_DIR=/mise`; the
 images do not configure `buildkite-gha`.

--- a/common/install-mise-toolchains.sh
+++ b/common/install-mise-toolchains.sh
@@ -123,15 +123,11 @@ canonical_mise trust /tmp/mise-ruby-project/mise.toml
   canonical_mise install --locked
 )
 
-# Node distributes Corepack with both pinned Node lines. Enable its Yarn shims
-# in each install and preload an exact default release into the shared image
-# cache so yarn works without a runtime bootstrap download.
+# Install Yarn into both Node installations.
 for version in "${NODE_22_VERSION}" "${NODE_24_VERSION}"; do
   node_root="${TOOLCHAIN_DATA_DIR}/installs/node/${version}"
-  PATH="${node_root}/bin:${PATH}" corepack enable yarn --install-directory "${node_root}/bin"
+  PATH="${node_root}/bin:${PATH}" npm install --global "yarn@${YARN_VERSION}"
 done
-PATH="${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}/bin:${PATH}" \
-  corepack install --global "yarn@${YARN_VERSION}"
 
 export RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_X64_ASSET}"
 export RUBY_ARCHIVE_SHA256="${RUBY_X64_SHA256#sha256:}"
@@ -188,7 +184,7 @@ for version in "${NODE_22_VERSION}" "${NODE_24_VERSION}"; do
   test -L "${canonical_root}/bin/yarn"
   test -f "$(readlink -f "${canonical_root}/bin/yarn")"
   test "$(PATH="${toolcache_root}/bin:${PATH}" node --version)" = "v${version}"
-  test "$(COREPACK_ENABLE_NETWORK=0 PATH="${toolcache_root}/bin:${PATH}" yarn --version)" = "${YARN_VERSION}"
+  test "$(PATH="${toolcache_root}/bin:${PATH}" yarn --version)" = "${YARN_VERSION}"
 done
 
 export NODE_24_ROOT="${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}"

--- a/common/install-mise-toolchains.sh
+++ b/common/install-mise-toolchains.sh
@@ -5,6 +5,7 @@ set -Eeufo pipefail
 : "${MISE_VERSION:?}"
 : "${NODE_22_VERSION:?}"
 : "${NODE_24_VERSION:?}"
+: "${YARN_VERSION:?}"
 
 export DEBIAN_ARCH="$(dpkg --print-architecture)"
 export TOOLCACHE_ARCH=x64
@@ -122,6 +123,16 @@ canonical_mise trust /tmp/mise-ruby-project/mise.toml
   canonical_mise install --locked
 )
 
+# Node distributes Corepack with both pinned Node lines. Enable its Yarn shims
+# in each install and preload an exact default release into the shared image
+# cache so yarn works without a runtime bootstrap download.
+for version in "${NODE_22_VERSION}" "${NODE_24_VERSION}"; do
+  node_root="${TOOLCHAIN_DATA_DIR}/installs/node/${version}"
+  PATH="${node_root}/bin:${PATH}" corepack enable yarn --install-directory "${node_root}/bin"
+done
+PATH="${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}/bin:${PATH}" \
+  corepack install --global "yarn@${YARN_VERSION}"
+
 export RUBY_ARCHIVE="${TOOLCHAIN_DATA_DIR}/downloads/ruby/${RUBY_VERSION}/${RUBY_X64_ASSET}"
 export RUBY_ARCHIVE_SHA256="${RUBY_X64_SHA256#sha256:}"
 if [ "${DEBIAN_ARCH}" = "arm64" ]; then
@@ -169,10 +180,15 @@ test ! -e /mise/bin/mise
 
 for version in "${NODE_22_VERSION}" "${NODE_24_VERSION}"; do
   canonical_root="${TOOLCHAIN_DATA_DIR}/installs/node/${version}"
+  toolcache_root="/opt/hostedtoolcache/node/${version}/${TOOLCACHE_ARCH}"
   test "$(readlink -f "$(mise where "node@${version}")")" = "${canonical_root}"
   test "$(mise exec "node@${version}" -- node --version)" = "v${version}"
   EXPECTED_NODE_VERSION="${version}" mise exec "node@${version}" -- node -e \
     'if (process.versions.node !== process.env.EXPECTED_NODE_VERSION) process.exit(1)'
+  test -L "${canonical_root}/bin/yarn"
+  test -f "$(readlink -f "${canonical_root}/bin/yarn")"
+  test "$(PATH="${toolcache_root}/bin:${PATH}" node --version)" = "v${version}"
+  test "$(COREPACK_ENABLE_NETWORK=0 PATH="${toolcache_root}/bin:${PATH}" yarn --version)" = "${YARN_VERSION}"
 done
 
 export NODE_24_ROOT="${TOOLCHAIN_DATA_DIR}/installs/node/${NODE_24_VERSION}"

--- a/ubuntu-jammy-hosted/Dockerfile
+++ b/ubuntu-jammy-hosted/Dockerfile
@@ -3,6 +3,7 @@
 ARG MISE_VERSION=v2026.8.3
 ARG NODE_22_VERSION=22.23.2
 ARG NODE_24_VERSION=24.18.0
+ARG YARN_VERSION=1.22.22
 
 FROM public.ecr.aws/ubuntu/ubuntu:22.04 AS base
 
@@ -111,6 +112,10 @@ FROM base AS toolchains
 ARG MISE_VERSION
 ARG NODE_22_VERSION
 ARG NODE_24_VERSION
+ARG YARN_VERSION
+
+ENV COREPACK_HOME="/opt/buildkite/mise-toolchains/corepack"
+ENV COREPACK_DEFAULT_TO_LATEST="0"
 
 RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \
   bash /tmp/install-mise-toolchains.sh

--- a/ubuntu-jammy-hosted/Dockerfile
+++ b/ubuntu-jammy-hosted/Dockerfile
@@ -114,9 +114,6 @@ ARG NODE_22_VERSION
 ARG NODE_24_VERSION
 ARG YARN_VERSION
 
-ENV COREPACK_HOME="/opt/buildkite/mise-toolchains/corepack"
-ENV COREPACK_DEFAULT_TO_LATEST="0"
-
 RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \
   bash /tmp/install-mise-toolchains.sh
 

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -3,6 +3,7 @@
 ARG MISE_VERSION=v2026.8.3
 ARG NODE_22_VERSION=22.23.2
 ARG NODE_24_VERSION=24.18.0
+ARG YARN_VERSION=1.22.22
 
 FROM public.ecr.aws/ubuntu/ubuntu:24.04 AS base
 
@@ -114,6 +115,10 @@ FROM base AS toolchains
 ARG MISE_VERSION
 ARG NODE_22_VERSION
 ARG NODE_24_VERSION
+ARG YARN_VERSION
+
+ENV COREPACK_HOME="/opt/buildkite/mise-toolchains/corepack"
+ENV COREPACK_DEFAULT_TO_LATEST="0"
 
 RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \
   bash /tmp/install-mise-toolchains.sh

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -117,9 +117,6 @@ ARG NODE_22_VERSION
 ARG NODE_24_VERSION
 ARG YARN_VERSION
 
-ENV COREPACK_HOME="/opt/buildkite/mise-toolchains/corepack"
-ENV COREPACK_DEFAULT_TO_LATEST="0"
-
 RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \
   bash /tmp/install-mise-toolchains.sh
 


### PR DESCRIPTION
## Why

Workflows using the opt-in Hosted toolchain images can select the preloaded Node versions but currently fail when they invoke `yarn`, unlike the practical `ubuntu-latest` workflow expectation. Yarn should be supplied by the image rather than installed by `buildkite-gha`.

## What

- pins Yarn Classic 1.22.22 for both Jammy and Noble toolchain targets
- installs it into both preloaded Node 22 and Node 24 installations
- validates `yarn --version` through each architecture-specific `/opt/hostedtoolcache` Node path