### PR TITLE
Automatically trigger image optimisation on main branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,7 +30,7 @@ steps:
     <<: *generate-variant-group
     label: ":pipeline: Upload {{variant}} group (branch)"
 
-  - block: ":rocket: Deploy *-hosted images to Namespace"
+  - wait: ~
     branches: "main"
 
   - trigger: "namespace-base-images-deployment"

--- a/.buildkite/steps/generate-variant-group-yml.sh
+++ b/.buildkite/steps/generate-variant-group-yml.sh
@@ -73,5 +73,8 @@ if [[ "${PUSH_IMAGE:-}" == "true" ]]; then
       - <<: *build-and-publish-variant
         label: ":docker: Publish ${variant} multiarch manifest"
         command: ".buildkite/steps/publish-multiarch-manifest.sh ${variant}"
+        retry:
+          automatic: true
+
 EOF
 fi


### PR DESCRIPTION
- Replace block step with wait step so we automatically trigger image optimisation when images have been built and published successfully.
- Also, add a retry to the manifest publishing step to account for newly uploaded images not becoming available immediately.