### PR TITLE
PB-2992: Add Docker to hosted toolchains variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Hosted toolchain variants preloaded with mise:
 - the latest stable Ruby for which mise has a precompiled binary
 - the latest Maven 3, also linked to `/usr/local/bin/mvn` (bring your own JDK,
   e.g. via `actions/setup-java`)
+- Docker Engine from Docker's apt repository, with the buildx and compose CLI
+  plugins (`docker compose`, no standalone `docker-compose`, matching GitHub
+  runner images); the daemon is not started or configured in the image
 
 The exact Node versions are the source of truth in the `-hosted` Dockerfiles and
 track the GitHub runner-image toolsets; Go, Ruby, and Maven resolve to exact

--- a/common/install-docker.sh
+++ b/common/install-docker.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Installs Docker Engine from Docker's official apt repository, mirroring
+# what GitHub Actions runner images provide on ubuntu-latest: the docker
+# CLI and daemon, containerd, and the buildx and compose CLI plugins.
+#
+# Like the GitHub runner images, there is no standalone `docker-compose`
+# binary; workflows use `docker compose`. The daemon is not configured or
+# started here; the hosted platform manages that at runtime.
+
+set -Eeufo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" |
+    tee /etc/apt/sources.list.d/docker.list >/dev/null
+
+# Full update: the base stage removes /var/lib/apt/lists, and docker-ce
+# depends on Ubuntu packages (iptables, nftables) beyond the docker repo.
+apt-get update
+apt-get install -y --no-install-recommends \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin
+
+docker --version
+docker buildx version
+docker compose version
+
+apt clean all
+rm -rf /var/lib/apt/lists/*

--- a/ubuntu-jammy-hosted/Dockerfile
+++ b/ubuntu-jammy-hosted/Dockerfile
@@ -117,6 +117,9 @@ ARG YARN_VERSION
 RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \
   bash /tmp/install-mise-toolchains.sh
 
+RUN --mount=type=bind,source=common/install-docker.sh,target=/tmp/install-docker.sh \
+  bash /tmp/install-docker.sh
+
 WORKDIR /root
 USER root
 

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -120,6 +120,9 @@ ARG YARN_VERSION
 RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \
   bash /tmp/install-mise-toolchains.sh
 
+RUN --mount=type=bind,source=common/install-docker.sh,target=/tmp/install-docker.sh \
+  bash /tmp/install-docker.sh
+
 WORKDIR /root
 USER root
 


### PR DESCRIPTION
Adds Docker to the `ubuntu-jammy-hosted-toolchains` and `ubuntu-noble-hosted-toolchains` variants so GitHub Actions workflows that run `docker build`, job containers, or service containers work on hosted agents.

Closes [PB-2992](https://linear.app/buildkite/issue/PB-2992/compatibility-gap-docker-is-missing-from-the-hosted-toolchain-image).

## What

- New shared `common/install-docker.sh`, bind-mounted into the `toolchains` stage of both `-hosted` Dockerfiles (the plain `hosted` tag stays slim).
- Installs Docker Engine from Docker's official apt repository: `docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, `docker-compose-plugin`.
- Mirrors GitHub runner images: buildx and compose are CLI plugins (`docker compose`; no standalone `docker-compose`, no `--compatibility` wrapper like the standard variants), no `daemon.json`, and the daemon is not started in the image — the hosted platform manages that at runtime.
- Smoke-tests `docker --version`, `docker buildx version`, and `docker compose version` during the build.

## Testing

- Ran `common/install-docker.sh` in clean `public.ecr.aws/ubuntu/ubuntu:24.04` and `:22.04` containers; all three version checks pass (Docker 29.7.2, buildx v0.36.1, Compose v5.5.0).
- shellcheck clean (one info-level SC1091, same as existing scripts).
