### PR TITLE
Add GitHub Actions compatibility packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Hosted toolchain variants preloaded with mise:
 - Docker Engine from Docker's apt repository, with the buildx and compose CLI
   plugins (`docker compose`, no standalone `docker-compose`, matching GitHub
   runner images); the daemon is not started or configured in the image
+- the Noble variant also includes a focused GitHub Actions compatibility set:
+  Clang, CMake, Ninja, GNU Fortran, common native-build headers, archive tools,
+  and system and network utilities frequently assumed by workflows
 
 The exact Node versions are the source of truth in the `-hosted` Dockerfiles and
 track the GitHub runner-image toolsets; Go, Ruby, and Maven resolve to exact

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Hosted toolchain variants preloaded with mise:
   plugins (`docker compose`, no standalone `docker-compose`, matching GitHub
   runner images); the daemon is not started or configured in the image
 - the Noble variant also includes a focused GitHub Actions compatibility set:
-  Clang, CMake, Ninja, GNU Fortran, common native-build headers, archive tools,
-  and system and network utilities frequently assumed by workflows
+  Clang, CMake, Ninja, common native-build headers, archive tools, and system
+  utilities frequently assumed by workflows
 
 The exact Node versions are the source of truth in the `-hosted` Dockerfiles and
 track the GitHub runner-image toolsets; Go, Ruby, and Maven resolve to exact

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -115,6 +115,7 @@ FROM base AS toolchains
 ARG MISE_VERSION
 ARG NODE_22_VERSION
 ARG NODE_24_VERSION
+ARG TARGETARCH
 ARG YARN_VERSION
 
 RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/install-mise-toolchains.sh \
@@ -122,6 +123,70 @@ RUN --mount=type=bind,source=common/install-mise-toolchains.sh,target=/tmp/insta
 
 RUN --mount=type=bind,source=common/install-docker.sh,target=/tmp/install-docker.sh \
   bash /tmp/install-docker.sh
+
+# Common build and system tools available on GitHub-hosted Ubuntu runners.
+# Keep this as the final toolchains layer so its image-size cost is visible.
+RUN --mount=type=cache,target=/var/cache/apt,id=gha-compat-apt-cache-${TARGETARCH},sharing=locked \
+--mount=type=cache,target=/var/lib/apt,id=gha-compat-apt-lib-${TARGETARCH},sharing=locked \
+<<BASH
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  autoconf \
+  automake \
+  bison \
+  bzip2 \
+  clang \
+  clang-format \
+  clang-tidy \
+  cmake \
+  dnsutils \
+  file \
+  flex \
+  gfortran \
+  gzip \
+  iproute2 \
+  iputils-ping \
+  libbz2-dev \
+  libffi-dev \
+  libicu-dev \
+  liblz4-dev \
+  liblzma-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  libtool \
+  libyaml-dev \
+  lld \
+  locales \
+  net-tools \
+  netcat-openbsd \
+  ninja-build \
+  p7zip-full \
+  patchelf \
+  pigz \
+  pkg-config \
+  procps \
+  python-is-python3 \
+  python3-venv \
+  shellcheck \
+  swig \
+  tar \
+  time \
+  tree \
+  tzdata \
+  wget \
+  xz-utils \
+  zlib1g-dev \
+  zstd
+
+apt clean all
+BASH
 
 WORKDIR /root
 USER root

--- a/ubuntu-noble-hosted/Dockerfile
+++ b/ubuntu-noble-hosted/Dockerfile
@@ -142,43 +142,26 @@ apt-get install -y --no-install-recommends \
   bison \
   bzip2 \
   clang \
-  clang-format \
-  clang-tidy \
   cmake \
-  dnsutils \
   file \
   flex \
-  gfortran \
   gzip \
   iproute2 \
-  iputils-ping \
   libbz2-dev \
   libffi-dev \
-  libicu-dev \
-  liblz4-dev \
+  libicu74 \
   liblzma-dev \
   libreadline-dev \
   libsqlite3-dev \
   libssl-dev \
   libtool \
   libyaml-dev \
-  lld \
-  locales \
-  net-tools \
-  netcat-openbsd \
   ninja-build \
-  p7zip-full \
-  patchelf \
-  pigz \
   pkg-config \
   procps \
   python-is-python3 \
   python3-venv \
-  shellcheck \
-  swig \
   tar \
-  time \
-  tree \
   tzdata \
   wget \
   xz-utils \


### PR DESCRIPTION
## Why

Workflows imported through `buildkite-gha` commonly assume the native-build, archive, and system utilities available on GitHub-hosted Ubuntu runners. The existing Noble toolchains image has the language toolchains and Docker stack, but lacks much of that compatibility substrate.

## What

Add a focused compatibility package layer to `ubuntu-noble-hosted-toolchains`, including Noble's default Clang, CMake and Ninja, native-build headers, archive formats used by setup/cache actions, and common system utilities. The layer is isolated to the opt-in toolchains target and placed last so its size contribution is visible in branch build output; `ubuntu-noble-hosted` remains unchanged.
